### PR TITLE
Changed the units for Mem and Swap from "M" to "MB" to avoid ambiguity.

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -439,7 +439,7 @@ SystemMonitor.prototype = {
         item.addActor(this.elements.memory.menu.used);
         item.addActor(new St.Label({ text: "/", style_class: "sm-label"}));
         item.addActor(this.elements.memory.menu.total);
-        item.addActor(new St.Label({ text: "M", style_class: "sm-label"}));
+        item.addActor(new St.Label({ text: "MB", style_class: "sm-label"}));
         item.connect('activate', Open_Window);
         section.addMenuItem(item);
 
@@ -450,7 +450,7 @@ SystemMonitor.prototype = {
         item.addActor(this.elements.swap.menu.used);
         item.addActor(new St.Label({ text: "/", style_class: "sm-label"}));
         item.addActor(this.elements.swap.menu.total);
-        item.addActor(new St.Label({ text: "M", style_class: "sm-label"}));
+        item.addActor(new St.Label({ text: "MB", style_class: "sm-label"}));
         item.connect('activate', Open_Window);
         section.addMenuItem(item);
 


### PR DESCRIPTION
The units for memory and swap where ambiguous, I added the suffix "B" for bytes to make them more clear.
