### PR TITLE
gnome-system-monito-applet bugfix

### DIFF
--- a/po/de_DE/system-monitor-applet.po
+++ b/po/de_DE/system-monitor-applet.po
@@ -3,6 +3,8 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Michael Pusterhofer <pusterhofer@student.tugraz.at>, 2011.
 
+msgid ""
+msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2011-06-06 10:56+0800\n"


### PR DESCRIPTION
Hi paradoxxxzero,
the german translation have a syntax error. It does not compile de_DE po. Here is a small fix. Plese pull my fork.

Regards
Waldemar 
