### PR TITLE
Option to show network speed in bits per second

### DIFF
--- a/org.gnome.shell.extensions.system-monitor.gschema.xml
+++ b/org.gnome.shell.extensions.system-monitor.gschema.xml
@@ -106,6 +106,10 @@
       <default>'graph'</default>
       <summary>Choose the display style.</summary>
     </key>
+    <key name="net-speed-in-bits" type="b">
+      <default>false</default>
+      <summary>Show network speed in bits/sec</summary>
+    </key>
     <key name="disk-display" type="b">
       <default>false</default>
       <summary>Display disk io speed</summary>

--- a/system-monitor-applet-config.py
+++ b/system-monitor-applet-config.py
@@ -130,10 +130,12 @@ class SettingFrame:
         self.hbox0 = Gtk.HBox(spacing=20)
         self.hbox1 = Gtk.HBox(spacing=20)
         self.hbox2 = Gtk.HBox(spacing=20)
+        self.hbox3 = Gtk.HBox(spacing=20)
         self.frame.add(self.vbox)
         self.vbox.pack_start(self.hbox0, True, False, 0)
         self.vbox.pack_start(self.hbox1, True, False, 0)
         self.vbox.pack_start(self.hbox2, True, False, 0)
+        self.vbox.pack_start(self.hbox3, True, False, 0)
 
     def add(self, key):
         sections = key.split('-')
@@ -165,6 +167,11 @@ class SettingFrame:
             item.set_value(self.schema.get_enum(key))
             self.hbox1.add(item.actor)
             item.selector.connect('changed', set_enum, self.schema, key)
+        elif sections[1] == 'speed':
+            item = Gtk.CheckButton(label=_('Show network speed in bits'))
+            item.set_active(self.schema.get_boolean(key))
+            self.hbox3.add(item)
+            item.connect('toggled', set_boolean, self.schema, key)
         elif len(sections) == 3 and sections[2] == 'color':
             item = ColorSelect(_(sections[1].capitalize()))
             item.set_value(self.schema.get_string(key))


### PR DESCRIPTION
This commit adds an option to report the network speed in bits per second rather than bytes per second.

This makes it easier to compare the system performance to hardware or network specs which are typically given in bits per second. For example, reporting 25,000 kbps rather than 3,125 kBps makes it easier to see that a Gigabit Ethernet interface is 25% utilized or that a "25 meg" broadband service is 100% utilized.
