### PR TITLE
Fix for the disk graph

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -696,7 +696,7 @@ var init = function (metadata) {
             this.last_time = time;
         },
         _apply: function() {
-            this.vals = this.usage;
+            this.vals = this.usage.slice();
             for (let i = 0;i < 2;i++) {    
                     if (this.usage[i] < 10)
                         this.usage[i] = this.usage[i].toFixed(1);


### PR DESCRIPTION
The disk graph was not drawing correctly for me - the graph showed I/O at 100% all the time. 

This patch makes it behave the way it should on my system.
