### PR TITLE
Add three digits form version to the shell version range

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/metadata.json
+++ b/system-monitor@paradoxxx.zero.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.2"],
+    "shell-version": ["3.2.0", "3.2"],
     "uuid": "system-monitor@paradoxxx.zero.gmail.com",
     "name": "system-monitor",
     "url": "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet",


### PR DESCRIPTION
Hi, it seems in _some_ cases the two digits gnome shell version is not enough to have the extension working... Most of the other extensions declare both version numbers.
