### PR TITLE
Add exception handling for missing network manager gir bindings

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -600,10 +600,15 @@ var init = function (metadata) {
             this.update_units();
             Schema.connect('changed::' + this.elt + '-speed-in-bits', Lang.bind(this, this.update_units));
             
-            let iface_list = this.client.get_devices();
-            this.NMsigID = []
-            for(let j = 0; j < iface_list.length; j++){
-            	this.NMsigID[j] = iface_list[j].connect('state-changed' , Lang.bind(this, this.update_iface_list));
+            try {
+                let iface_list = this.client.get_devices();
+                this.NMsigID = []
+                for(let j = 0; j < iface_list.length; j++){
+            	    this.NMsigID[j] = iface_list[j].connect('state-changed' , Lang.bind(this, this.update_iface_list));
+                }
+            }
+            catch(e) {
+                global.logError("Please install Network Manager Gobject Introspection Bindings");
             }
             this.update();
         },


### PR DESCRIPTION
should allow fall-back to old code when network manager is missing
