### PR TITLE
README.md: add fedora package names for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Dependencies:
     
     python3
     python3-gobject
-    libgtop and gir bindings (gir1.2-gtop-2.0, gir1.2-networkmanager-1.0 on Ubuntu)
+    libgtop and gir bindings
+        on Ubuntu: gir1.2-gtop-2.0, gir1.2-networkmanager-1.0
+        on Fedora: libgtop2-devel, NetworkManager-glib-devel
 
 Install git if you don't have it: (sudo apt-get install git-core, sudo pacman -S git, etc)
 Then:


### PR DESCRIPTION
Just an extra line of documentation; it might save some people a few minutes.
