### PR TITLE
check all temp?_input files in hwmon directories

### DIFF
--- a/system-monitor-applet-config.py
+++ b/system-monitor-applet-config.py
@@ -74,7 +74,7 @@ def check_sensors():
             if not os.path.isfile(test):
                 test = sensor_path + 'hwmon' + str(j) + '/device/' + sfile
                 if not os.path.isfile(test):
-                    break
+                    continue
             
             sensor = os.path.split(test)
             infile = open(sensor[0] + '/name', "r")


### PR DESCRIPTION
Some /sys/class/hwmon/hwmon? directories only contain temp2\* and temp4*
files. Thus skipping the remaining files in case of a non-existing
temp1_input file results in no detected sensors at all.
