### PR TITLE
pref.js: fix TypeError when /sys/class/hwmon is empty

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -204,7 +204,7 @@ const SettingFrame = new Lang.Class({
             let [_slist, _strlist] = check_sensors();
             let item = new Select(_('Sensor'));
             if (_slist.length == 0){
-                item.add(_('Please install lm-sensors'));
+                item.add([_('Please install lm-sensors')]);
             } else if (_slist.length == 1){
                 this.schema.set_string(key, _slist[0]);
             }


### PR DESCRIPTION
When /sys/class/hwmon was empty, Select.add() whould raise TypeError:
    item.forEach is not a function
This patch fixes it.
