### PR TITLE
Fix less-than-500ms interval value and allow fluid, quick refreshed graphs (e.g. of CPU usage)

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -410,7 +410,7 @@ const ElementBase = new Lang.Class({
                           }));
 
             this.interval = l_limit(Schema.get_int(this.elt + "-refresh-time"));
-            this.timeout = Mainloop.timeout_add_seconds(Math.round(this.interval/1000),
+            this.timeout = Mainloop.timeout_add(this.interval,
                                                 Lang.bind(this, this.update));
             Schema.connect(
                 'changed::' + this.elt + '-refresh-time',
@@ -418,7 +418,7 @@ const ElementBase = new Lang.Class({
                           function(schema, key) {
                               Mainloop.source_remove(this.timeout);
                               this.interval = l_limit(Schema.get_int(key));
-                              this.timeout = Mainloop.timeout_add_seconds(Math.round(this.interval/1000),
+                              this.timeout = Mainloop.timeout_add(this.interval,
                                                                   Lang.bind(this, this.update));
                           }));
             Schema.connect('changed::' + this.elt + '-graph-width',


### PR DESCRIPTION
Fixes a graphical bug that was triggered when a value below 500 was chosen (e.g. for CPU usage): since the value was rounded, the result timeout value (in seconds) was 0 and graph was messed up.

Also enables to have quicky refreshed graphs. CPU usage does not seem to suffer.

Tested on Ubuntu 12.04, Gnome-shell 3.4.1-0ubuntu2.
