### PR TITLE
Update patch-5

### DIFF
--- a/po/system-monitor-applet.pot
+++ b/po/system-monitor-applet.pot
@@ -16,6 +16,10 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: prefs.js:69 prefs.js:90 prefs.js:110
+msgid ":"
+msgstr ""
+
 #: prefs.js:161
 msgid "Display"
 msgstr ""


### PR DESCRIPTION
Added ":" to internationalization functions as in some languages (for example in french) a non breakable space is needed in front of ":" ";" "?" "!".
