### PR TITLE
Update patch-6

### DIFF
--- a/po/fr_FR/system-monitor-applet.po
+++ b/po/fr_FR/system-monitor-applet.po
@@ -7,13 +7,17 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2012-06-21 06:49+1000\n"
-"PO-Revision-Date: 2012-06-20 12:46+0200\n"
+"PO-Revision-Date: 2012-06-24 12:46+0200\n"
 "Last-Translator: Nicolas Viéville <nicolas.vieville@univ-valenciennes.fr>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: prefs.js:69 prefs.js:90 prefs.js:110
+msgid ":"
+msgstr " :"
 
 #: prefs.js:161
 msgid "Display"


### PR DESCRIPTION
Added ":" to internationalization functions as in some languages (for example in french) a non breakable space is needed in front of ":" ";" "?" "!".
