### PR TITLE
Added option to display CPU cores in separate graphs. 

### DIFF
--- a/po/fr/system-monitor-applet.po
+++ b/po/fr/system-monitor-applet.po
@@ -55,10 +55,6 @@ msgstr "Couleur de fond"
 msgid "Show network speed in bits"
 msgstr "Afficher le débit réseau en bits"
 
-#: prefs.js:196
-msgid "Show compact text"
-msgstr" Compacter le texte"
-
 #: prefs.js:197
 msgid "Display Individual Cores"
 msgstr "Afficher tous les coeurs"
@@ -74,6 +70,10 @@ msgstr "Veuillez installer lm-sensors, s'il vous plaît"
 #: prefs.js:282
 msgid "Move the clock"
 msgstr "Déplacer l'horloge"
+
+#: prefs.js:286
+msgid "Compact Display"
+msgstr "Affichage Compact"
 
 #: extension.js:746
 msgid "Cpu"

--- a/po/system-monitor-applet.pot
+++ b/po/system-monitor-applet.pot
@@ -60,10 +60,6 @@ msgstr ""
 msgid "Show network speed in bits"
 msgstr ""
 
-#:prefs.js:196
-msgid "Compact text"
-msgstr ""
-
 #: prefs.js:205
 msgid "Sensor"
 msgstr ""
@@ -74,6 +70,10 @@ msgstr ""
 
 #: prefs.js:282
 msgid "Move the clock"
+msgstr ""
+
+#:prefs.js:286
+msgid "Compact Display"
 msgstr ""
 
 #: extension.js:746


### PR DESCRIPTION
Hi,
I added an option to display CPU cores in separate graphs.
I could only test it with a dual core, but I guess it should be OK with more cores.
I don't know much about javascript so sorry for the poor code,
hope you can merge it anyway..
Thanks for this nice extension anyway...
(Issue #103).
