### PR TITLE
Update po/fr/system-monitor.po

### DIFF
--- a/po/fr/system-monitor.po
+++ b/po/fr/system-monitor.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2012-06-21 06:49+1000\n"
-"PO-Revision-Date: 2012-09-05 07:22+0200\n"
+"PO-Revision-Date: 2012-09-19 07:22+0200\n"
 "Last-Translator: Nicolas Viéville <nicolas.vieville@univ-valenciennes.fr>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -327,6 +327,14 @@ msgstr "ventilateur"
 #: extension.js:1542 extension.js:1566 extension.js:1574
 msgid "rpm"
 msgstr "tr/min"
+
+#: extension.js:1182
+msgid "R"
+msgstr "R"
+
+#: extension.js:1185
+msgid "W"
+msgstr "W"
 
 #~ msgid "System Monitor Applet Configurator"
 #~ msgstr "Configuration de l’applet moniteur système"


### PR DESCRIPTION
Hello,

Maybe it should be necessary to update system-monitor.pot to reflect R and W additions. This file is not editable in GitHub repository. Here is the the code:
# : extension.js:1182

msgid "R"
msgstr ""
# : extension.js:1185

msgid "W"
msgstr ""

Thanks again for this great extension.

Cordially,
## 

NVieville
