### PR TITLE
A fix for Issue #211 (CPU Graph isn't updated after a resume from suspend on Arch Linux)

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1055,6 +1055,11 @@ const Cpu = new Lang.Class({
                     this.last[i] = this.current[i];
                 }
                 this.last_total = this.gtop.total;
+            } else if (delta < 0) {
+                this.last = [0,0,0,0,0];
+                this.current = [0,0,0,0,0];
+                this.last_total = 0;
+                this.usage = [0,0,0,1,0];
             }
         }
         // display per cpu data


### PR DESCRIPTION
On some systems, delta can be negative after the computer suspends and resumes; previously, this would cause the CPU graph to only update using the usage level from when delta was last positive.
