### PR TITLE
Improve function existance checking

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/compat.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/compat.js
@@ -4,8 +4,7 @@ const Clutter = imports.gi.Clutter;
 function color_from_string(color){
     let clutterColor, res;
 
-    let shell_Version = Config.PACKAGE_VERSION;
-    if (shell_Version < "3.5.4"){
+    if (!Clutter.Color.from_string){
         clutterColor = new Clutter.Color();
         clutterColor.from_string(color);
     } else {


### PR DESCRIPTION
You originally check on the gnome-shell version. However, Debian testing version of gnome-shell is 3.4.2, but seem's like that they backported something, because new Clutter.Color() is broken while Clutter.Color.from_string works. 
Instead, you can check about the existance of the from_string function in Color.
This should work for both older and newer systems.
