### PR TITLE
Avoid freezes on SFTP/MTP mounts

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -433,7 +433,7 @@ const smMountsMonitor = new Lang.Class({
             let file = mount.get_default_location();
             let info = file.query_filesystem_info(Gio.FILE_ATTRIBUTE_FILESYSTEM_TYPE, null);
             let result = info.get_attribute_string(Gio.FILE_ATTRIBUTE_FILESYSTEM_TYPE);
-            return (result == 'nfs' || result == 'smbfs' || result == 'cifs' || result == 'ftp');
+            return (result == 'sftp' || result == 'mtp' || || result == 'mtpfs' || result == 'nfs' || result == 'smbfs' || result == 'cifs' || result == 'ftp');
         } catch(e) {
             return false;
         }


### PR DESCRIPTION
Workaround for #207 when copying files from/to SFTP or MTP mounts.

Is there a reason why we can't use the [is_native()](https://developer.gnome.org/glibmm/stable/classGio_1_1File.html#aaa3b910bc9f240d4ebd0efc70979f163) method there? It seems to me that it would handle most edge cases properly, and both SFTP and MTP would have been handled by this.
