### PR TITLE
Fix mount checks

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -393,7 +393,6 @@ const smMountsMonitor = new Lang.Class({
         let mount_lines = this._volumeMonitor.get_mounts();
         mount_lines.forEach(Lang.bind(this, function(mount) {
             if ( !this.is_ro_mount(mount) &&
-                 !this.is_sys_mount(mount) &&
                 (!this.is_net_mount(mount) || ENABLE_NETWORK_DISK_USAGE)) {
 
                 let mpath = mount.get_root().get_path() || mount.get_default_location().get_path();

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -435,7 +435,10 @@ const smMountsMonitor = new Lang.Class({
             let file = mount.get_default_location();
             let info = file.query_filesystem_info(Gio.FILE_ATTRIBUTE_FILESYSTEM_TYPE, null);
             let result = info.get_attribute_string(Gio.FILE_ATTRIBUTE_FILESYSTEM_TYPE);
-            return (result == 'nfs' || result == 'smbfs' || result == 'cifs' || result == 'ftp' || result == 'sshfs');
+            return !file.is_native() || (result == 'nfs' || 
+                result == 'smbfs' || result == 'cifs' || result == 'ftp' || 
+                result == 'sshfs' || result == 'sftp' || result == 'mtp' ||
+                result == 'mtpfs');
         } catch(e) {
             return false;
         }


### PR DESCRIPTION
Do not recheck sys mounts, since this causes failure in loading (is_sys_mount expects a string, but mount is an object; there is no point in getting the mount path since the check was actually useless).

As per the net part, I added both is_native() and the additional filesystems mentioned in #257, since I wasn't able to test the filesystems involved.
The [is_native() documentation](https://developer.gnome.org/glibmm/stable/classGio_1_1File.html#aaa3b910bc9f240d4ebd0efc70979f163) states
> This (is_native() returning true) does not mean the file is local, as it might be on a locally mounted remote filesystem.

but also

>On some systems non-native files may be available using the native filesystem via a userspace filesystem (FUSE), in these cases this call will return false

So is_native() might be useful in some but not all use cases, where we fallback to the filesystem type.

Correct me if you think I got something wrong, I'm not so expert about filesystems and mounts, expecially networks ones. 4c3a876ecc9c65edecb73a449731ed8b48620032 must be merged to allow the extension to start, however. (My fault, I tought my repository was symlinked to ~/.local/.../extensions, which wasn't the case, so I didn't test my previous pull request)