### PR TITLE
Fix check for visible item

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -860,7 +860,7 @@ const ElementBase = new Lang.Class({
               }
               },*/
     update: function() {
-        if (!this.menu_visible || !this.actor.visible)
+        if (!this.menu_visible && !this.actor.visible)
             return;
         this.refresh();
         this._apply();


### PR DESCRIPTION
Well, I'm producing a bunch of pull request filled with errors to be fixed :) sorry
This one caused stats to be refreshed only if the stat was shown in both menu and applet. Now it's only needed to have it shown in one of them to trigger refresh.