### PR TITLE
add GNOME Shell 3.16 as supported version

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/metadata.json
+++ b/system-monitor@paradoxxx.zero.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.4","3.6","3.8","3.10", "3.12", "3.14"],
+    "shell-version": ["3.4","3.6","3.8","3.10", "3.12", "3.14", "3.16"],
     "uuid": "system-monitor@paradoxxx.zero.gmail.com",
     "name": "system-monitor",
     "url": "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet",


### PR DESCRIPTION
TODO: color selection is broken in 3.16