### PR TITLE
Add FreeBSD support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *~
 tmp
+*.gir
 *.pyc
+*.so
 *.swp
+*.typelib

--- a/system-monitor@paradoxxx.zero.gmail.com/Makefile
+++ b/system-monitor@paradoxxx.zero.gmail.com/Makefile
@@ -1,0 +1,43 @@
+.PHONY: all clean distclean
+
+# Commands
+INTROSPECTION_SCANNER = g-ir-scanner
+INTROSPECTION_COMPILER = g-ir-compiler
+
+# Arguments
+SMSYSDEPS_CFLAGS = -fPIC -shared -Wall -O2
+
+# Sources
+CFILES = sysdeps/system-monitor-sysdeps.c
+HFILES = sysdeps/system-monitor-sysdeps.h
+
+# Compiled shared object
+SOLIB  = system-monitor-sysdeps
+SOFILE = sysdeps/lib$(SOLIB).so
+
+# Compiled gir and typelib file
+NAMESPACE = SystemMonitorSysdeps
+NSVERSION = 0.1
+SMPREFIX = system_monitor_sysdeps
+GIRFILE = sysdeps/$(NAMESPACE)-$(NSVERSION).gir
+TYPELIBFILE = $(GIRFILE:.gir=.typelib)
+
+all: $(TYPELIBFILE)
+distclean: clean
+
+$(SOFILE): $(CFILES) $(HFILES)
+	$(CC) $(SMSYSDEPS_CFLAGS) $(CFLAGS) $(CFILES) -o $(SOFILE) $(LDFLAGS)
+$(GIRFILE): $(SOFILE)
+	LD_LIBRARY_PATH=./sysdeps:${LD_LIBRARY_PATH} $(INTROSPECTION_SCANNER) \
+		$(CFILES) $(HFILES) \
+		-Lsysdeps \
+		--library=$(SOLIB) \
+		--namespace=$(NAMESPACE) \
+		--nsversion=$(NSVERSION) \
+		--symbol-prefix=$(SMPREFIX) \
+		--output=$(GIRFILE)
+$(TYPELIBFILE): $(GIRFILE)
+	$(INTROSPECTION_COMPILER) $(GIRFILE) -o $(TYPELIBFILE)
+
+clean:
+	rm -f $(SOFILE) $(GIRFILE) $(TYPELIBFILE)

--- a/system-monitor@paradoxxx.zero.gmail.com/Makefile
+++ b/system-monitor@paradoxxx.zero.gmail.com/Makefile
@@ -3,9 +3,14 @@
 # Commands
 INTROSPECTION_SCANNER = g-ir-scanner
 INTROSPECTION_COMPILER = g-ir-compiler
+PKG_CONFIG = pkg-config
 
 # Arguments
-SMSYSDEPS_CFLAGS = -fPIC -shared -Wall -O2
+SMSYSDEPS_PKGS = glib-2.0
+SMSYSDEPS_PKGS_CFLAGS = `$(PKG_CONFIG) --cflags $(SMSYSDEPS_PKGS)`
+SMSYSDEPS_PKGS_LIBS = `$(PKG_CONFIG) --libs $(SMSYSDEPS_PKGS)`
+SMSYSDEPS_CFLAGS = -fPIC -shared -Wall -O2 $(SMSYSDEPS_PKGS_CFLAGS)
+SMSYSDEPS_LIBS = $(SMSYSDEPS_PKGS_LIBS)
 
 # Sources
 CFILES = sysdeps/system-monitor-sysdeps.c
@@ -26,11 +31,13 @@ all: $(TYPELIBFILE)
 distclean: clean
 
 $(SOFILE): $(CFILES) $(HFILES)
-	$(CC) $(SMSYSDEPS_CFLAGS) $(CFLAGS) $(CFILES) -o $(SOFILE) $(LDFLAGS)
+	$(CC) $(SMSYSDEPS_CFLAGS) $(CFLAGS) $(CFILES) -o $(SOFILE) \
+		$(SMSYSDEPS_PKGS_LIBS) $(LDFLAGS)
 $(GIRFILE): $(SOFILE)
 	LD_LIBRARY_PATH=./sysdeps:${LD_LIBRARY_PATH} $(INTROSPECTION_SCANNER) \
 		$(CFILES) $(HFILES) \
 		-Lsysdeps \
+		--include=GLib-2.0 \
 		--library=$(SOLIB) \
 		--namespace=$(NAMESPACE) \
 		--nsversion=$(NSVERSION) \

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -77,6 +77,14 @@ const ENABLE_NETWORK_DISK_USAGE = false;
 
 let extension = imports.misc.extensionUtils.getCurrentExtension();
 let metadata = extension.metadata;
+let kernel = false;
+
+try {
+    kernel = GLib.spawn_command_line_sync('uname')[1].toString().trim();
+} catch(e) {
+    log(e);
+    kernel = 'Linux';
+}
 
 let Schema, Background, IconSize, Style, MountsMonitor, StatusArea;
 let menu_timeout, gc_timeout;

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -20,6 +20,7 @@
 
 let smDepsGtop = true;
 let smDepsNM = true;
+let smCompiled = true;
 
 const Config = imports.misc.config;
 const Clutter = imports.gi.Clutter;

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1878,6 +1878,9 @@ var enable = function () {
         }
 
         MountsMonitor.connect();
+        if (GTop.glibtop_init) {
+            GTop.glibtop_init();
+        }
 
         //Debug
         Main.__sm = {

--- a/system-monitor@paradoxxx.zero.gmail.com/sysdeps/system-monitor-sysdeps.c
+++ b/system-monitor@paradoxxx.zero.gmail.com/sysdeps/system-monitor-sysdeps.c
@@ -1,8 +1,13 @@
 #include "system-monitor-sysdeps.h"
+#include <glib.h>
 
 #ifdef __FreeBSD__
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <net/if_types.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
@@ -26,4 +31,45 @@ int system_monitor_sysdeps_sysctl_dev_cpu_0_freq (void) {
 }
 #undef MIB_LEN
 
+/**
+ * system_monitor_sysdeps_getifaddrs_up_not_loopback_or_bridge:
+ *
+ * Returns: (element-type utf8) (transfer full)
+ */
+GSList* system_monitor_sysdeps_getifaddrs_up_not_loopback_or_bridge (void) {
+    struct ifaddrs *ifap;
+    if (getifaddrs (&ifap) == -1) {
+        return NULL;
+    }
+    if (ifap == NULL) {
+        return NULL;
+    }
+
+    GSList *ifs = NULL;
+    const char *name = ifap->ifa_name;
+    bool is_up = true, is_loopback = false, is_bridge = false;
+    for (struct ifaddrs *ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
+        if (strcmp (ifa->ifa_name, name) != 0) {
+            if (is_up && !is_loopback && !is_bridge) {
+                ifs = g_slist_prepend (ifs, g_strdup (name));
+            }
+            is_up = true, is_loopback = false, is_bridge = false;
+        }
+        name = ifa->ifa_name;
+        is_up = is_up && (ifa->ifa_flags & IFF_UP);
+        is_loopback = is_loopback || (ifa->ifa_flags & IFF_LOOPBACK);
+        if (ifa->ifa_addr->sa_family == AF_LINK) {
+            struct if_data *ifd = ifa->ifa_data;
+            is_bridge = is_bridge || (ifd->ifi_type == IFT_BRIDGE);
+        }
+        if (ifa->ifa_next == NULL) {
+            if (is_up && !is_loopback && !is_bridge) {
+                ifs = g_slist_prepend (ifs, g_strdup (name));
+            }
+        }
+    }
+
+    freeifaddrs (ifap);
+    return ifs;
+}
 #endif

--- a/system-monitor@paradoxxx.zero.gmail.com/sysdeps/system-monitor-sysdeps.c
+++ b/system-monitor@paradoxxx.zero.gmail.com/sysdeps/system-monitor-sysdeps.c
@@ -1,0 +1,29 @@
+#include "system-monitor-sysdeps.h"
+
+#ifdef __FreeBSD__
+#include <stdbool.h>
+#include <stddef.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+#define MIB_LEN 4
+int system_monitor_sysdeps_sysctl_dev_cpu_0_freq (void) {
+    static bool init;
+    static int mib[MIB_LEN];
+
+    if (!init) {
+        if (sysctlnametomib ("dev.cpu.0.freq", mib, &(size_t){ MIB_LEN }) == -1) {
+            return -1;
+        }
+        init = true;
+    }
+
+    int freq;
+    if (sysctl (mib, MIB_LEN, &freq, &(size_t){ sizeof (freq) }, NULL, 0) == -1) {
+        return -1;
+    }
+    return freq;
+}
+#undef MIB_LEN
+
+#endif

--- a/system-monitor@paradoxxx.zero.gmail.com/sysdeps/system-monitor-sysdeps.h
+++ b/system-monitor@paradoxxx.zero.gmail.com/sysdeps/system-monitor-sysdeps.h
@@ -1,3 +1,5 @@
+#include <glib.h>
 #ifdef __FreeBSD__
-int system_monitor_sysdeps_sysctl_dev_cpu_0_freq (void);
+int         system_monitor_sysdeps_sysctl_dev_cpu_0_freq (void);
+GSList*     system_monitor_sysdeps_getifaddrs_up_not_loopback_or_bridge (void);
 #endif

--- a/system-monitor@paradoxxx.zero.gmail.com/sysdeps/system-monitor-sysdeps.h
+++ b/system-monitor@paradoxxx.zero.gmail.com/sysdeps/system-monitor-sysdeps.h
@@ -1,0 +1,3 @@
+#ifdef __FreeBSD__
+int system_monitor_sysdeps_sysctl_dev_cpu_0_freq (void);
+#endif


### PR DESCRIPTION
This pull request changes following things:
1. Detect currently running operating system at runtime instead of assuming we always use Linux.
2. Make NetworkManager optional on non-Linux systems.
3. Call glibtop_init if it is available in `enable()` to prevent odd crashes.
4. Make it possible to write system-dependent code in C.
5. Port Freq and Net element to FreeBSD.

Current status on FreeBSD:
- Working: CPU, Memory, Swap, Net, Disk, Freq
- Broken: Thermal, Fan
- Not tested: Battery
