### PR TITLE
Fix manual install in 3.16: needs to enable extension with gnome-shell-extension-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Then:
     mkdir -p ~/.local/share/gnome-shell/extensions
     cd ~/.local/share/gnome-shell/extensions
     ln -s ~/git_projects/gnome-shell-system-monitor-applet/system-monitor@paradoxxx.zero.gmail.com
+    gnome-shell-extension-tool --enable-extension=system-monitor@paradoxxx.zero.gmail.com
 
 And restart gnome-shell (Alt + F2 -> r) or reboot.
 


### PR DESCRIPTION
I had a problem with Gnome shell 3.16 and automatic install via extensions.gnome.org : extensions doesn't install and nothing in logs. I didn't searched a lot around and tried manual install.
After manual install procedure, extension wasn't enabled; I needed to enable it (via *https://extensions.gnome.org/local/* or *gnome-shell-extension-tool*), so adding it in manual install procedure seems to be a good idea, don't you think ?