### PR TITLE
Gnome 3.8 Branch for EL7 - fix for noisy logs when hwmon devices are not available

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1568,7 +1568,7 @@ const Thermal = new Lang.Class({
                 this.temperature = Math.round(parseInt(as_r[1]) / 1000);
             }));
         } else {
-            global.logError("error reading: " + sfile);
+            //global.logError("error reading: " + sfile);
         }
     },
     _apply: function() {
@@ -1615,7 +1615,7 @@ const Fan = new Lang.Class({
                 this.rpm = parseInt(as_r[1]);
             }));
         } else {
-            global.logError("error reading: " + sfile);
+            //global.logError("error reading: " + sfile);
         }
     },
     _apply: function() {


### PR DESCRIPTION
PR to fix issue #259 for Gnome 3.8 and provide better support to EL7 users.  I'd suggest taking this PR off as a new branch similar to what you've done with gnome-3.0 and gnome-3.2, although I'm not sure how you do that exactly.

This branch was picked up at the most recent commit (cc86a28) which works for Gnome 3.8.