### PR TITLE
Enable Gnome 3.20

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/metadata.json
+++ b/system-monitor@paradoxxx.zero.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.4","3.6","3.8","3.10", "3.12", "3.14", "3.16", "3.18"],
+    "shell-version": ["3.4","3.6","3.8","3.10", "3.12", "3.14", "3.16", "3.18", "3.20"],
     "uuid": "system-monitor@paradoxxx.zero.gmail.com",
     "name": "system-monitor",
     "url": "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet",


### PR DESCRIPTION
I've just tested the applet on openSUSE Tumbleweed with gnome 3.20.