### PR TITLE
Fix #272.

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -487,7 +487,7 @@ const Graph = new Lang.Class({
         this.actor.connect('repaint', Lang.bind(this, this._draw));
         this.gtop = new GTop.glibtop_fsusage();
         // FIXME Handle colors correctly
-        this.colors = ["#444", "#666", "#888", "#aaa", "#ccc", "#eee"];
+        this.colors = ["#888", "#aaa", "#ccc"];
         for(let color in this.colors) {
             this.colors[color] = color_from_string(this.colors[color]);
         }


### PR DESCRIPTION
Change colors used for disk graphs to be better readable with Adwaita theme.
![issue-272](https://cloud.githubusercontent.com/assets/2658545/21079889/39bcc2b8-bfa0-11e6-8aaa-00eaf428a3e8.png)

Fixes #272 