### PR TITLE
Ignore interfaces like *br* in Net.update_iface_list also

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1510,7 +1510,10 @@ const Net = new Lang.Class({
             let iface_list = this.client.get_devices();
             for(let j = 0; j < iface_list.length; j++){
                 if (iface_list[j].state == NetworkManager.DeviceState.ACTIVATED){
-                    this.ifs.push(iface_list[j].get_ip_iface() || iface_list[j].get_iface());
+                  ifc = iface_list[j].get_ip_iface() || iface_list[j].get_iface();
+                  if (ifc.indexOf("br") < 0){
+                     this.ifs.push(ifc);
+                   }
                 }
             }
         }


### PR DESCRIPTION
When building current iface-list within class Net _init from /proc/net/dev, bridge-interfaces are excluded to avoid double count of traffic.
But this isn't done within class function update_iface_list, where the class gets its interfaces via NMClient.Client.