### PR TITLE
Fix runtime error in GNOME 3.24

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -40,16 +40,19 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 const Compat = Me.imports.compat;
 
+let GTop;
 try {
-    const GTop = imports.gi.GTop;
+    GTop = imports.gi.GTop;
 } catch(e) {
     log(e);
     smDepsGtop = false;
 }
 
+let NMClient;
+let NetworkManager;
 try {
-    const NMClient = imports.gi.NMClient;
-    const NetworkManager = imports.gi.NetworkManager;
+    NMClient = imports.gi.NMClient;
+    NetworkManager = imports.gi.NetworkManager;
 } catch(e) {
     log(e);
     smDepsNM = false;


### PR DESCRIPTION
Declare GTop and NetworkManager outside of try-catch scope

Fixes #341 