### PR TITLE
Use kbit/s instead of kbps

### DIFF
--- a/po/system-monitor.pot
+++ b/po/system-monitor.pot
@@ -253,6 +253,14 @@ msgstr ""
 msgid "MiB/s"
 msgstr ""
 
+#: extension.js:178 extension.js:1597 extension.js:1605
+msgid "kbit/s"
+msgstr ""
+
+#: extension.js:179 extension.js:1600 extension.js:1608
+msgid "Mbit/s"
+msgstr ""
+
 #: extension.js:1419 extension.js:1635
 msgid "MiB"
 msgstr ""

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -175,8 +175,8 @@ const smStyleManager = new Lang.Class({
     _diskunits: _('MiB/s'),
     _netunits_kbytes: _('KiB/s'),
     _netunits_mbytes: _('MiB/s'),
-    _netunits_kbits: 'kbps',
-    _netunits_mbits: 'Mbps',
+    _netunits_kbits: _('kbit/s'),
+    _netunits_mbits: _('Mbit/s'),
     _pie_width: 300,
     _pie_height: 300,
     _pie_fontsize: 14,
@@ -1594,18 +1594,18 @@ const Net = new Lang.Class({
             this.tip_vals[2] = Math.round(this.tip_vals[2] * 8.192);
             if (this.tip_vals[0] < 1000) {
                 this.text_items[2].text = Style.netunits_kbits();
-                this.menu_items[1].text = this.tip_unit_labels[0].text = 'kbps';
+                this.menu_items[1].text = this.tip_unit_labels[0].text = _('kbit/s');
             } else {
                 this.text_items[2].text = Style.netunits_mbits();
-                this.menu_items[1].text = this.tip_unit_labels[0].text = 'Mbps';
+                this.menu_items[1].text = this.tip_unit_labels[0].text = _('Mbit/s');
                 this.tip_vals[0] = (this.tip_vals[0] / 1000).toPrecision(3);
             }
             if (this.tip_vals[2] < 1000) {
                 this.text_items[5].text = Style.netunits_kbits();
-                this.menu_items[4].text = this.tip_unit_labels[2].text = 'kbps';
+                this.menu_items[4].text = this.tip_unit_labels[2].text = _('kbit/s');
             } else {
                 this.text_items[5].text = Style.netunits_mbits();
-                this.menu_items[4].text = this.tip_unit_labels[2].text = 'Mbps';
+                this.menu_items[4].text = this.tip_unit_labels[2].text = _('Mbit/s');
                 this.tip_vals[2] = (this.tip_vals[2] / 1000).toPrecision(3);
             }
         } else {


### PR DESCRIPTION
Hi,

This PR is a proposal to change
- `kbps` to `kbit/s`
- `Mbps` to `Mbit/s`

as the units shown when using the option "Show network speed in bits". This was originally proposed by @DevDef in issue #359.

The second commit in this PR is simply updating the general file for translations, so that it's easier to track strings that need to be translated.