### PR TITLE
Update CPU freqency to read from /sys fs

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1461,15 +1461,12 @@ const Freq = new Lang.Class({
         this.update();
     },
     refresh: function () {
-        let lines = Shell.get_file_contents_utf8_sync('/proc/cpuinfo').split('\n');
-        for (let i = 0; i < lines.length; i++) {
-            let line = lines[i];
-            if (line.search(/cpu mhz/i) < 0) {
-                continue;
-            }
-            this.freq = parseInt(line.substring(line.indexOf(':') + 2));
-            break;
+        let total_frequency = 0;
+        let num_cpus = GTop.glibtop_get_sysinfo().ncpu;
+        for (let i = 0; i < num_cpus; i++) {
+          total_frequency += parseInt(Shell.get_file_contents_utf8_sync('/sys/devices/system/cpu/cpu' + i + '/cpufreq/scaling_cur_freq'));
         }
+        this.freq = Math.round(total_frequency / num_cpus / 1000);
     },
     _apply: function () {
         let value = this.freq.toString();


### PR DESCRIPTION
`/proc/cpuinfo` is deprecated, so this is now reading values from the `/sys` fs and then averaging the frequency of the cores instead of taking the last value.

Fixes #391 