### PR TITLE
Fix missing Schema object when unlocking the screen

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -20,7 +20,7 @@
 
 /* Ugly. This is here so that we don't crash old libnm-glib based shells unnecessarily
  * by loading the new libnm.so. Should go away eventually */
-const libnm_glib = imports.gi.GIRepository.Repository.get_default().is_registered("NMClient", "1.0");
+const libnm_glib = imports.gi.GIRepository.Repository.get_default().is_registered('NMClient', '1.0');
 
 let smDepsGtop = true;
 let smDepsNM = true;
@@ -1483,7 +1483,7 @@ const Freq = new Lang.Class({
         let total_frequency = 0;
         let num_cpus = GTop.glibtop_get_sysinfo().ncpu;
         for (let i = 0; i < num_cpus; i++) {
-          total_frequency += parseInt(Shell.get_file_contents_utf8_sync('/sys/devices/system/cpu/cpu' + i + '/cpufreq/scaling_cur_freq'));
+            total_frequency += parseInt(Shell.get_file_contents_utf8_sync('/sys/devices/system/cpu/cpu' + i + '/cpufreq/scaling_cur_freq'));
         }
         this.freq = Math.round(total_frequency / num_cpus / 1000);
     },

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2230,6 +2230,11 @@ var init = function () {
         Locale = Locale.split('_')[0];
     }
 
+    IconSize = Math.round(Panel.PANEL_ICON_SIZE * 4 / 5);
+};
+
+var enable = function () {
+    log('System monitor applet enabling');
     Schema = Convenience.getSettings();
 
     Style = new smStyleManager();
@@ -2237,11 +2242,6 @@ var init = function () {
 
     Background = color_from_string(Schema.get_string('background'));
 
-    IconSize = Math.round(Panel.PANEL_ICON_SIZE * 4 / 5);
-};
-
-var enable = function () {
-    log('System monitor applet enabling');
     if (!(smDepsGtop && smDepsNM)) {
         Main.__sm = {
             smdialog: new smDialog()
@@ -2423,7 +2423,14 @@ var disable = function () {
     //        Main.__sm.elts[i].hide_system_icon(false);
     // }
 
-    MountsMonitor.disconnect();
+    if (MountsMonitor) {
+        MountsMonitor.disconnect();
+        MountsMonitor = null;
+    }
+
+    if (Style) {
+        Style = null;
+    }
 
     Schema.run_dispose();
     for (let eltName in Main.__sm.elts) {


### PR DESCRIPTION
Hopefully addresses #419

The problem was that the Schema was created in `init()`, and then destroyed in `disable()`.

I moved the creation to `enable()` so that it gets created properly when needed, i.e. with each new session.