### PR TITLE
limit number of cores to poll for frequency

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1481,7 +1481,7 @@ const Freq = new Lang.Class({
     },
     refresh: function () {
         let total_frequency = 0;
-        let num_cpus = GTop.glibtop_get_sysinfo().ncpu;
+        let num_cpus = Math.min(GTop.glibtop_get_sysinfo().ncpu, 4);
         for (let i = 0; i < num_cpus; i++) {
           total_frequency += parseInt(Shell.get_file_contents_utf8_sync('/sys/devices/system/cpu/cpu' + i + '/cpufreq/scaling_cur_freq'));
         }


### PR DESCRIPTION
/sys/devices/system/cpu/cpu??/cpufreq/scaling_cur_freq takes a significant amount of time per poll, and the entire system becomes unresponsive if there are enough cores.

For example, on my 56-core workstation, polling all 56 of those takes ~1.5 seconds.  If the frequency update interval is set to 1 second, as per default, there is no possibility for the poll to complete in time.  The poll necessarily takes a long time, because a delay is built into the check to average out the frequency for that core already.

This was not a problem with the old /proc/cpufreq interface because this data was cached, so a read from cpufreq returned far faster.  However, in the recent kernel versions, this data is no longer updated dynamically - but there's talk on the kernel mailing list of a way of polling this more quickly again in future.  Meanwhile, this limits the frequency of cpus to the first four, to reduce any unnecessary delays.