### PR TITLE
Update metadata.json

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/metadata.json
+++ b/system-monitor@paradoxxx.zero.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.4","3.6","3.8","3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26"],
+    "shell-version": ["3.4","3.6","3.8","3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26", "3.28"],
     "uuid": "system-monitor@paradoxxx.zero.gmail.com",
     "name": "system-monitor",
     "url": "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet",


### PR DESCRIPTION
As Gnome 3.28 has been published, maybe it would be worth upgrading metadata.json if compatible.

Cordially,


-- 
NVieville