### PR TITLE
Update gpu_usage.sh

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/gpu_usage.sh
+++ b/system-monitor@paradoxxx.zero.gmail.com/gpu_usage.sh
@@ -25,4 +25,4 @@
 nvidia-smi -i 0 -q -d MEMORY | grep -A4 -i gpu | egrep -i "used|total" | awk '{print $3}'
 
 # This line will print the GPU usage in %.
-nvidia-smi -i 0 -q -d UTILIZATION | grep Gpu | awk '{print $3}'
+sed -e 's#.*=\(\)#\1#;s'/.$//'' <<< $(nvidia-settings -q all | grep -i GPUUtilization | grep graphics | awk '{print $4}')


### PR DESCRIPTION
nvidia-smi doesn't seem to work very well for people, nvidia-settings seems more reliable. For me the following change grabbed the gpu utilization from nvidia-settings instead of from nvidia-smi and it works great.