### PR TITLE
close unwanted file descriptors

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2133,13 +2133,22 @@ const Gpu = new Lang.Class({
             let path = Me.dir.get_path();
             let script = ['/bin/bash', path + '/gpu_usage.sh'];
 
-            let [, pid, , out_fd, ] = GLib.spawn_async_with_pipes(
+            let [, pid, in_fd, out_fd, err_fd] = GLib.spawn_async_with_pipes(
                 null,
                 script,
                 null,
                 GLib.SpawnFlags.DO_NOT_REAP_CHILD,
                 null);
 
+            let _tmp_stream = new Gio.DataInputStream({
+                base_stream: new Gio.UnixInputStream({fd: in_fd})
+            });
+            _tmp_stream.close(null);
+            _tmp_stream = new Gio.DataInputStream({
+                base_stream: new Gio.UnixInputStream({fd: err_fd})
+            });
+            _tmp_stream.close(null);
+            
             // Let's buffer the command's output - that's an input for us !
             this._process_stream = new Gio.DataInputStream({
                 base_stream: new Gio.UnixInputStream({fd: out_fd})


### PR DESCRIPTION
Fixes: #458

This closes the unwanted _stdin_ and _stderr_ file descriptors which if left unclosed will leak on each iteration.

Not sure if/that this is the most straightforward way of doing this in a GNOME Shell extension but it seems to work.  It does seem that there could/should be an easier way to close a file descriptor than using `Gio.DataInputStream()` and `Gio.UnixInputStream` but I'm not a GNOME Shell, nor even JS hacker.  Suggestions welcome.