### PR TITLE
Makefile: complete rewrite with target 'help'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ help:
 	@echo  '  zip-file  - build and zip ./$(UUID).zip'
 	@echo  '  reload    - reload extension $(UUID)'
 	@echo  '  clean     - remove most generated files'
-	@echo  '  extension - remove most generated files'
+	@echo  '  extension - rebuild schemas/gschemas.compiled'
 	@echo  '  translate - generate translation from po/ files'
 	@echo  ''
 	@echo  'control verbosity:'

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ install: remove build
 	$(call msg,$@,$(SUDO) $(INSTALLBASE)/$(INSTALLNAME))
 	$(Q) $(SUDO) mkdir -p $(INSTALLBASE)/$(INSTALLNAME)
 	$(Q) $(SUDO) cp $(VV) -r ./_build/* $(INSTALLBASE)/$(INSTALLNAME)/
-	$(Q) $(MAKE) reload -s
+	$(Q) $(MAKE) -s reload
 	$(call msg,$@,OK)
 
 remove:

--- a/Makefile
+++ b/Makefile
@@ -1,61 +1,176 @@
+# -*- coding: utf-8; mode: makefile-gmake -*-
 # Basic Makefile
 
 UUID = system-monitor@paradoxxx.zero.gmail.com
-BASE_MODULES = $(UUID)/extension.js $(UUID)/README* $(UUID)/metadata.json $(UUID)/prefs.js $(UUID)/stylesheet.css $(UUID)/convenience.js $(UUID)/compat.js $(UUID)/gpu_usage.sh
+INSTALLNAME = $(UUID)
+DESTDIR ?=
+
+BASE_MODULES = \
+  $(UUID)/extension.js \
+  $(UUID)/README* \
+  $(UUID)/metadata.json \
+  $(UUID)/prefs.js \
+  $(UUID)/stylesheet.css \
+  $(UUID)/convenience.js \
+  $(UUID)/compat.js \
+  $(UUID)/gpu_usage.sh
+
+# ---------
+# variables
+# ---------
+
 ifeq ($(strip $(DESTDIR)),)
-	INSTALLBASE = $(HOME)/.local/share/gnome-shell/extensions
+  INSTALLBASE = $(HOME)/.local/share/gnome-shell/extensions
+  SUDO=
 else
-	INSTALLBASE = $(DESTDIR)/usr/share/gnome-shell/extensions
+  INSTALLBASE = $(DESTDIR)usr/share/gnome-shell/extensions
+  SUDO=sudo
 endif
-INSTALLNAME = system-monitor@paradoxxx.zero.gmail.com
 
-# The command line passed variable VERSION is used to set the version string
-# in the metadata and in the generated zip-file. If no VERSION is passed, the
-# current commit SHA1 is used as version number in the metadata while the
-# generated zip file has no string attached.
 ifdef VERSION
-	VSTRING = _v$(VERSION)
+  VSTRING = _v$(VERSION)
 else
-	VERSION = $(shell git rev-parse HEAD)
-	VSTRING =
+  VERSION = $(shell git rev-parse HEAD)
+  VSTRING =
 endif
 
-all: extension
+# VERBOSE level
 
-clean:
-	rm -f ./$(UUID)/schemas/gschemas.compiled
+ifeq ($(V),1)
+  Q =
+  VV = -v
+else
+  Q = @
+  VV =
+endif
 
-extension: ./$(UUID)/schemas/gschemas.compiled
+# -------
+# macros
+# -------
+
+# usage: $(call reload-extension $(UUID))
+
+reload-extension = $(shell gnome-shell-extension-tool -r $(1))
+
+# usage: $(call msg,INFO,'lorem ipsum')
+msg = @printf '  [%-12s] %s\n' '$(1)' '$(2)'
+
+
+# -------
+# targets
+# -------
+
+# is there anymore use of the (old) 'all' target?
+# PHONY += all
+# all: extension
+
+PHONY += help
+help:
+	@echo  'Install or remove (and reload) of the extension, for the local user'
+	@echo  'or as admin for all users:'
+	@echo  ''
+	@echo  '  make [install|remove]                        # for the local user'
+	@echo  '  make DESTDIR=/ [install|remove] clean        # as admin for all users'
+	@echo  ''
+	@echo  'Use environment VERSION=n.m to set verison string in the metadata and in'
+	@echo  'the generated zip-file explicit.  If no VERSION is passed, the current'
+	@echo  'commit SHA1 is used as version number in the metadata while the generated'
+	@echo  'zip file has no string attached.'
+	@echo  ''
+	@echo  'Other targets are:'
+	@echo  ''
+	@echo  '  zip-file  - build and zip ./$(UUID).zip'
+	@echo  '  reload    - reload extension $(UUID)'
+	@echo  '  clean     - remove most generated files'
+	@echo  '  extension - remove most generated files'
+	@echo  '  translate - generate translation from po/ files'
+	@echo  ''
+	@echo  'control verbosity:'
+	@echo  ''
+	@echo  '  make V=0 [targets] -> quiet build (default)'
+	@echo  '  make V=1 [targets] -> verbose build'
+
+
+PHONY += install remove
+
+install: remove build
+	$(call msg,$@,$(SUDO) $(INSTALLBASE)/$(INSTALLNAME))
+	$(Q) $(SUDO) mkdir -p $(INSTALLBASE)/$(INSTALLNAME)
+	$(Q) $(SUDO) cp $(VV) -r ./_build/* $(INSTALLBASE)/$(INSTALLNAME)/
+	$(Q) $(MAKE) reload -s
+	$(call msg,$@,OK)
+
+remove:
+	$(call msg,$@,$(SUDO) $(INSTALLBASE)/$(INSTALLNAME))
+	$(Q) $(SUDO) rm $(VV) -fr $(INSTALLBASE)/$(INSTALLNAME)
+	$(Q) $(MAKE) -s reload
+	$(call msg,$@,OK)
+
+reload:
+	$(call reload-extension $(UUID))
+	$(call msg,$@,OK)
+
+
+PHONY += zip-file zip-file.clean
+ZIPFILE=$(UUID)$(VSTRING).zip
+
+zip-file: build.clean build
+	$(Q)cd _build ; zip $(V) -qr $(ZIPFILE) .
+	$(Q)mv _build/$(ZIPFILE) ./$(ZIPFILE)
+	$(call msg,$@,OK)
+
+clean:: zip-file.clean
+zip-file.clean:
+	$(Q)rm $(VV) -f $(ZIPFILE)
+	$(call msg,$@,OK)
+
+
+PHONY += extension extension.clean _drop-gschemas
+
+extension: _drop-gschemas ./$(UUID)/schemas/gschemas.compiled
+	$(call msg,$@,OK)
+
+clean:: extension.clean
+extension.clean:
+	$(Q)git checkout -f -- ./$(UUID)/schemas/gschemas.compiled
+	$(call msg,$@,OK)
 
 ./$(UUID)/schemas/gschemas.compiled: ./$(UUID)/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
-	glib-compile-schemas ./$(UUID)/schemas/
+	$(Q)glib-compile-schemas ./$(UUID)/schemas/
+	$(call msg,gschemas,OK)
 
-install: install-local
+_drop-gschemas:
+	$(Q)rm -f ./$(UUID)/schemas/gschemas.compiled
 
-install-local: _build
-	rm -rf $(INSTALLBASE)/$(INSTALLNAME)
-	mkdir -p $(INSTALLBASE)/$(INSTALLNAME)
-	cp -r ./_build/* $(INSTALLBASE)/$(INSTALLNAME)/
-	-rm -fR _build
-	echo done
 
-zip-file: _build
-	cd _build ; \
-	zip -qr "$(UUID)$(VSTRING).zip" .
-	mv _build/$(UUID)$(VSTRING).zip ./
-	-rm -fR _build
+PHONY += build build.clean
 
-_build: update-translation
-	-rm -fR ./_build
-	mkdir -p _build
-	cp $(BASE_MODULES) _build
-	mkdir -p _build/locale
-	cp -r $(UUID)/locale/* _build/locale/
-	mkdir -p _build/schemas
-	cp $(UUID)/schemas/*.xml _build/schemas/
-	cp $(UUID)/schemas/gschemas.compiled _build/schemas/
-	sed -i 's/"version": -1/"version": "$(VERSION)"/'  _build/metadata.json;
+build: translate
+	$(Q)mkdir -p _build
+	$(Q)cp $(VV) $(BASE_MODULES) _build
+	$(Q)mkdir -p _build/locale
+	$(Q)cp $(VV) -r $(UUID)/locale/* _build/locale/
+	$(Q)mkdir -p _build/schemas
+	$(Q)cp $(VV) $(UUID)/schemas/*.xml _build/schemas/
+	$(Q)cp $(VV)  $(UUID)/schemas/gschemas.compiled _build/schemas/
+	$(Q)sed -i 's/"version": -1/"version": "$(VERSION)"/'  _build/metadata.json;
+	$(call msg,$@,OK)
 
-update-translation: all
-	cd po; \
-	./compile.sh ../system-monitor@paradoxxx.zero.gmail.com/locale;
+clean:: build.clean
+build.clean:
+	$(Q)rm -fR ./_build
+	$(call msg,$@,OK)
+
+PHONY += translate
+translate: extension
+	$(Q)cd po;\
+           ./compile.sh ../system-monitor@paradoxxx.zero.gmail.com/locale \
+	   | tr '\n' ' ' \
+	   | sed -e 's/^/  [$@   ] /;'; echo
+	$(call msg,$@,OK)
+
+clean:: translation.clean
+translation.clean:
+	$(Q)git checkout -f -- system-monitor@paradoxxx.zero.gmail.com/locale
+
+.PHONY: $(PHONY)

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ BASE_MODULES = \
 # variables
 # ---------
 
-INSTALLBASE = $(DESTDIR)/usr/share/gnome-shell/extensions
-
 ifeq ($(strip $(DESTDIR)),$(HOME))
+  INSTALLBASE = $(DESTDIR)/.local/share/gnome-shell/extensions
   SUDO=
 else
+INSTALLBASE = $(DESTDIR)/usr/share/gnome-shell/extensions
   SUDO=sudo
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ remove:
 	$(call msg,$@,OK)
 
 reload:
-	$(call reload-extension $(UUID))
+	$(call reload-extension,$(UUID))
 	$(call msg,$@,OK)
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 UUID = system-monitor@paradoxxx.zero.gmail.com
 INSTALLNAME = $(UUID)
-DESTDIR ?=
+DESTDIR ?= $(HOME)
 
 BASE_MODULES = \
   $(UUID)/extension.js \
@@ -19,11 +19,11 @@ BASE_MODULES = \
 # variables
 # ---------
 
-ifeq ($(strip $(DESTDIR)),)
-  INSTALLBASE = $(HOME)/.local/share/gnome-shell/extensions
+INSTALLBASE = $(DESTDIR)/usr/share/gnome-shell/extensions
+
+ifeq ($(strip $(DESTDIR)),$(HOME))
   SUDO=
 else
-  INSTALLBASE = $(DESTDIR)usr/share/gnome-shell/extensions
   SUDO=sudo
 endif
 


### PR DESCRIPTION
The 'help' target describe this patch as best:

$ make help
Install or remove (and reload) of the extension, for the local user
or as admin for all users:

  make [install|remove]                        # for the local user
  make DESTDIR=/ [install|remove] clean        # as admin for all users

Use environment VERSION=n.m to set verison string in the metadata and in
the generated zip-file explicit.  If no VERSION is passed, the current
commit SHA1 is used as version number in the metadata while the generated
zip file has no string attached.

Other targets are:

  zip-file  - build and zip ./system-monitor@paradoxxx.zero.gmail.com.zip
  reload    - reload extension system-monitor@paradoxxx.zero.gmail.com
  clean     - remove most generated files
  extension - remove most generated files
  translate - generate translation from po/ files

control verbosity:

  make V=0 [targets] -> quiet build (default)
  make V=1 [targets] -> verbose build

Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>