### PR TITLE
Make it work with gnome-shell 3.32

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,8 @@
     //enable nodejs environment
     "node": 1,
     //enable browser environment
-    "browser": 1
+    "browser": 1,
+    "es6": true
   },
   "parserOptions": {
     "ecmaVersion": 6

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -20,31 +20,31 @@
 
 /* Ugly. This is here so that we don't crash old libnm-glib based shells unnecessarily
  * by loading the new libnm.so. Should go away eventually */
-const libnm_glib = imports.gi.GIRepository.Repository.get_default().is_registered('NMClient', '1.0');
 
-let smDepsGtop = true;
-let smDepsNM = true;
+var libnm_glib = imports.gi.GIRepository.Repository.get_default().is_registered('NMClient', '1.0');
 
-const Config = imports.misc.config;
-const Clutter = imports.gi.Clutter;
-const GLib = imports.gi.GLib;
+var smDepsGtop = true;
+var smDepsNM = true;
 
-const Gio = imports.gi.Gio;
-const Lang = imports.lang;
-const Shell = imports.gi.Shell;
-const St = imports.gi.St;
-const Power = imports.ui.status.power;
+var Config = imports.misc.config;
+var Clutter = imports.gi.Clutter;
+var GLib = imports.gi.GLib;
+
+var Gio = imports.gi.Gio;
+var Shell = imports.gi.Shell;
+var St = imports.gi.St;
+var Power = imports.ui.status.power;
 // const System = imports.system;
-const ModalDialog = imports.ui.modalDialog;
+var ModalDialog = imports.ui.modalDialog;
 
-const ExtensionSystem = imports.ui.extensionSystem;
-const ExtensionUtils = imports.misc.extensionUtils;
+var ExtensionSystem = imports.ui.extensionSystem;
+var ExtensionUtils = imports.misc.extensionUtils;
 
-const Me = ExtensionUtils.getCurrentExtension();
-const Convenience = Me.imports.convenience;
-const Compat = Me.imports.compat;
+var Me = ExtensionUtils.getCurrentExtension();
+var Convenience = Me.imports.convenience;
+var Compat = Me.imports.compat;
 
-let Background, GTop, IconSize, Locale, MountsMonitor, NM, NetworkManager, Schema, StatusArea, Style, gc_timeout, menu_timeout;
+var Background, GTop, IconSize, Locale, MountsMonitor, NM, NetworkManager, Schema, StatusArea, Style, gc_timeout, menu_timeout;
 
 try {
     GTop = imports.gi.GTop;
@@ -168,25 +168,25 @@ function interesting_mountpoint(mount) {
 }
 
 
-const smStyleManager = new Lang.Class({
-    Name: 'SystemMonitor.smStyleManager',
-    _extension: '',
-    _iconsize: 1,
-    _diskunits: _('MiB/s'),
-    _netunits_kbytes: _('KiB/s'),
-    _netunits_mbytes: _('MiB/s'),
-    _netunits_kbits: _('kbit/s'),
-    _netunits_mbits: _('Mbit/s'),
-    _pie_width: 300,
-    _pie_height: 300,
-    _pie_fontsize: 14,
-    _bar_width: 300,
-    _bar_height: 150,
-    _bar_fontsize: 14,
-    _text_scaling: 1,
+const smStyleManager = class SystemMonitor_smStyleManager {
 
-    _init: function () {
+    constructor () {
+        this._extension = '';
+        this._iconsize = 1;
+        this._diskunits = _('MiB/s');
+        this._netunits_kbytes = _('KiB/s');
+        this._netunits_mbytes = _('MiB/s');
+        this._netunits_kbits = _('kbit/s');
+        this._netunits_mbits = _('Mbit/s');
+        this._pie_width = 300;
+        this._pie_height = 300;
+        this._pie_fontsize = 14;
+        this._bar_width = 300;
+        this._bar_height = 150;
+        this._bar_fontsize = 14;
+        this._text_scaling = 1;
         this._compact = Schema.get_boolean('compact-display');
+
         if (this._compact) {
             this._extension = '-compact';
             this._iconsize = 3 / 5;
@@ -210,57 +210,55 @@ const smStyleManager = new Lang.Class({
         if (!this._text_scaling) {
             this._text_scaling = 1;
         }
-    },
-    get: function (style) {
+    }
+    get (style) {
         return style + this._extension;
-    },
-    iconsize: function () {
+    }
+    iconsize () {
         return this._iconsize;
-    },
-    diskunits: function () {
+    }
+    diskunits () {
         return this._diskunits;
-    },
-    netunits_kbytes: function () {
+    }
+    netunits_kbytes () {
         return this._netunits_kbytes;
-    },
-    netunits_mbytes: function () {
+    }
+    netunits_mbytes () {
         return this._netunits_mbytes;
-    },
-    netunits_kbits: function () {
+    }
+    netunits_kbits () {
         return this._netunits_kbits;
-    },
-    netunits_mbits: function () {
+    }
+    netunits_mbits () {
         return this._netunits_mbits;
-    },
-    pie_width: function () {
+    }
+    pie_width () {
         return this._pie_width;
-    },
-    pie_height: function () {
+    }
+    pie_height () {
         return this._pie_height;
-    },
-    pie_fontsize: function () {
+    }
+    pie_fontsize () {
         return this._pie_fontsize * this._text_scaling;
-    },
-    bar_width: function () {
+    }
+    bar_width () {
         return this._bar_width;
-    },
-    bar_height: function () {
+    }
+    bar_height () {
         return this._bar_height;
-    },
-    bar_fontsize: function () {
+    }
+    bar_fontsize () {
         return this._bar_fontsize * this._text_scaling;
-    },
-    text_scaling: function () {
+    }
+    text_scaling () {
         return this._text_scaling;
-    },
-});
+    }
+}
 
-const smDialog = Lang.Class({
-    Name: 'SystemMonitor.smDialog',
-    Extends: ModalDialog.ModalDialog,
+const smDialog = class SystemMonitor_smDialog extends ModalDialog.ModalDialog {
 
-    _init: function () {
-        this.parent({styleClass: 'prompt-dialog'});
+    constructor () {
+        super({styleClass: 'prompt-dialog'});
         let mainContentBox = new St.BoxLayout({style_class: 'prompt-dialog-main-layout',
             vertical: false});
         this.contentLayout.add(mainContentBox,
@@ -290,31 +288,30 @@ const smDialog = Lang.Class({
         this.setButtons([
             {
                 label: _('Cancel'),
-                action: Lang.bind(this, function () {
+                action: () => {
                     this.close();
-                }),
+                },
                 key: Clutter.Escape
             }
         ]);
-    },
+    }
 
-});
+}
 
-const Chart = new Lang.Class({
-    Name: 'SystemMonitor.Chart',
+const Chart = class SystemMonitor_Chart {
 
-    _init: function (width, height, parent) {
+    constructor (width, height, parent) {
         this.actor = new St.DrawingArea({style_class: Style.get('sm-chart'), reactive: false});
         this.parentC = parent;
         this.actor.set_width(this.width = width);
         this.actor.set_height(this.height = height);
-        this.actor.connect('repaint', Lang.bind(this, this._draw));
+        this.actor.connect('repaint', this._draw.bind(this));
         this.data = [];
         for (let i = 0; i < this.parentC.colors.length; i++) {
             this.data[i] = [];
         }
-    },
-    update: function () {
+    }
+    update () {
         let data_a = this.parentC.vals;
         if (data_a.length !== this.parentC.colors.length) {
             return;
@@ -331,8 +328,8 @@ const Chart = new Lang.Class({
             return;
         }
         this.actor.queue_repaint();
-    },
-    _draw: function () {
+    }
+    _draw () {
         if (!this.actor.visible) {
             return;
         }
@@ -361,8 +358,8 @@ const Chart = new Lang.Class({
         if (Compat.versionCompare(shell_Version, '3.7.4')) {
             cr.$dispose();
         }
-    },
-    resize: function (schema, key) {
+    }
+    resize (schema, key) {
         let old_width = this.width;
         this.width = Schema.get_int(key);
         if (old_width === this.width) {
@@ -375,55 +372,56 @@ const Chart = new Lang.Class({
             }
         }
     }
-});
+}
 
 // Class to deal with volumes insertion / ejection
-const smMountsMonitor = new Lang.Class({
-    Name: 'SystemMonitor.smMountsMonitor',
-    files: [],
-    num_mounts: -1,
-    listeners: [],
-    connected: false,
-    _init: function () {
+const smMountsMonitor = class SystemMonitor_smMountsMonitor {
+
+    constructor () {
+        this.files = [];
+        this.num_mounts = -1;
+        this.listeners = [];
+        this.connected = false;
+
         this._volumeMonitor = Gio.VolumeMonitor.get();
         let sys_mounts = ['/home', '/tmp', '/boot', '/usr', '/usr/local'];
         this.base_mounts = ['/'];
-        sys_mounts.forEach(Lang.bind(this, function (sMount) {
+        sys_mounts.forEach( (sMount) => {
             if (this.is_sys_mount(sMount + '/')) {
                 this.base_mounts.push(sMount);
             }
-        }));
+        });
         this.connect();
-    },
-    refresh: function () {
+    }
+    refresh () {
         // try check that number of volumes has changed
-        /* try {
-            let num_mounts = this.manager.getMounts().length;
-            if (num_mounts == this.num_mounts)
-                return;
-            this.num_mounts = num_mounts;
-        } catch (e) {};*/
+        // try {
+        //     let num_mounts = this.manager.getMounts().length;
+        //     if (num_mounts == this.num_mounts)
+        //         return;
+        //     this.num_mounts = num_mounts;
+        // } catch (e) {};
 
         // Can't get mountlist:
         // GTop.glibtop_get_mountlist
         // Error: No symbol 'glibtop_get_mountlist' in namespace 'GTop'
         // Getting it with mtab
-        /* let mount_lines = Shell.get_file_contents_utf8_sync('/etc/mtab').split("\n");
-        this.mounts = [];
-        for(let mount_line in mount_lines) {
-            let mount = mount_lines[mount_line].split(" ");
-            if(interesting_mountpoint(mount) && this.mounts.indexOf(mount[1]) < 0) {
-                this.mounts.push(mount[1]);
-            }
-        }
-        log("[System monitor] old mounts: " + this.mounts);*/
+        // let mount_lines = Shell.get_file_contents_utf8_sync('/etc/mtab').split("\n");
+        // this.mounts = [];
+        // for(let mount_line in mount_lines) {
+        //     let mount = mount_lines[mount_line].split(" ");
+        //     if(interesting_mountpoint(mount) && this.mounts.indexOf(mount[1]) < 0) {
+        //         this.mounts.push(mount[1]);
+        //     }
+        // }
+        // log("[System monitor] old mounts: " + this.mounts);
         this.mounts = [];
         for (let base in this.base_mounts) {
             // log("[System monitor] " + this.base_mounts[base]);
             this.mounts.push(this.base_mounts[base]);
         }
         let mount_lines = this._volumeMonitor.get_mounts();
-        mount_lines.forEach(Lang.bind(this, function (mount) {
+        mount_lines.forEach( (mount) => {
             if ((!this.is_net_mount(mount) || ENABLE_NETWORK_DISK_USAGE) &&
                  !this.is_ro_mount(mount)) {
                 let mpath = mount.get_root().get_path() || mount.get_default_location().get_path();
@@ -431,29 +429,29 @@ const smMountsMonitor = new Lang.Class({
                     this.mounts.push(mpath);
                 }
             }
-        }));
+        });
         // log("[System monitor] base: " + this.base_mounts);
         // log("[System monitor] mounts: " + this.mounts);
         for (let i in this.listeners) {
             this.listeners[i](this.mounts);
         }
-    },
-    add_listener: function (cb) {
+    }
+    add_listener (cb) {
         this.listeners.push(cb);
-    },
-    remove_listener: function (cb) {
+    }
+    remove_listener (cb) {
         this.listeners.pop(cb);
-    },
-    get_mounts: function () {
+    }
+    get_mounts () {
         return this.mounts;
-    },
-    is_sys_mount: function (mpath) {
+    }
+    is_sys_mount (mpath) {
         let file = Gio.file_new_for_path(mpath);
         let info = file.query_info(Gio.FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT,
             Gio.FileQueryInfoFlags.NONE, null);
         return info.get_attribute_boolean(Gio.FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT);
-    },
-    is_ro_mount: function (mount) {
+    }
+    is_ro_mount (mount) {
         // FIXME: running this function after "login after waking from suspend"
         // can make login hang. Actual issue seems to occur when a former net
         // mount got broken (e.g. due to a VPN connection terminated or
@@ -465,8 +463,8 @@ const smMountsMonitor = new Lang.Class({
         } catch (e) {
             return false;
         }
-    },
-    is_net_mount: function (mount) {
+    }
+    is_net_mount (mount) {
         try {
             let file = mount.get_default_location();
             let info = file.query_filesystem_info(Gio.FILE_ATTRIBUTE_FILESYSTEM_TYPE, null);
@@ -476,15 +474,15 @@ const smMountsMonitor = new Lang.Class({
         } catch (e) {
             return false;
         }
-    },
-    connect: function () {
+    }
+    connect () {
         if (this.connected) {
             return;
         }
         try {
             this.manager = this._volumeMonitor;
-            this.mount_added_id = this.manager.connect('mount-added', Lang.bind(this, this.refresh));
-            this.mount_removed_id = this.manager.connect('mount-removed', Lang.bind(this, this.refresh));
+            this.mount_added_id = this.manager.connect('mount-added', this.refresh.bind(this));
+            this.mount_removed_id = this.manager.connect('mount-removed', this.refresh.bind(this));
             // need to add the other signals here
             this.connected = true;
         } catch (e) {
@@ -492,58 +490,57 @@ const smMountsMonitor = new Lang.Class({
             log('[System monitor] Got exception : ' + e);
         }
         this.refresh();
-    },
-    disconnect: function () {
+    }
+    disconnect () {
         if (!this.connected) {
             return;
         }
         this.manager.disconnect(this.mount_added_id);
         this.manager.disconnect(this.mount_removed_id);
         this.connected = false;
-    },
-    destroy: function () {
+    }
+    destroy () {
         this.disconnect();
     }
-});
+}
 
-const Graph = new Lang.Class({
-    Name: 'SystemMonitor.Graph',
+const Graph = class SystemMonitor_Graph {
 
-    menu_item: '',
-    _init: function () {
+    constructor (width, height) {
+        this.menu_item = '';
         this.actor = new St.DrawingArea({style_class: Style.get('sm-chart'), reactive: false});
-        this.width = arguments[0][0];
-        this.height = arguments[0][1];
+        this.width = width;
+        this.height = height;
         this.actor.set_width(this.width);
         this.actor.set_height(this.height);
-        this.actor.connect('repaint', Lang.bind(this, this._draw));
+        this.actor.connect('repaint', this._draw.bind(this));
         this.gtop = new GTop.glibtop_fsusage();
         this.colors = ['#888', '#aaa', '#ccc'];
         for (let color in this.colors) {
             this.colors[color] = color_from_string(this.colors[color]);
         }
-    },
-    create_menu_item: function () {
+    }
+    create_menu_item () {
         this.menu_item = new PopupMenu.PopupBaseMenuItem({reactive: false});
         this.menu_item.actor.add(this.actor, {span: -1, expand: true});
         // tray.menu.addMenuItem(this.menu_item);
-    },
-    show: function (visible) {
+    }
+    show (visible) {
         this.menu_item.actor.visible = visible;
     }
-});
-const Bar = new Lang.Class({
-    Name: 'SystemMonitor.Bar',
-    Extends: Graph,
-    _init: function () {
+}
+
+const Bar = class SystemMonitor_Bar extends Graph {
+
+    constructor (width, height) {
+        super(width, height);
         this.mounts = MountsMonitor.get_mounts();
-        MountsMonitor.add_listener(Lang.bind(this, this.update_mounts));
+        MountsMonitor.add_listener(this.update_mounts.bind(this));
         this.thickness = 15 * Style.text_scaling();
         this.fontsize = Style.bar_fontsize();
-        this.parent(arguments);
         this.actor.set_height(this.mounts.length * (3 * this.thickness));
-    },
-    _draw: function () {
+    }
+    _draw () {
         if (!this.actor.visible) {
             return;
         }
@@ -578,21 +575,22 @@ const Bar = new Lang.Class({
         if (Compat.versionCompare(shell_Version, '3.7.4')) {
             cr.$dispose();
         }
-    },
-    update_mounts: function (mounts) {
+    }
+    update_mounts (mounts) {
         this.mounts = mounts;
         this.actor.queue_repaint();
     }
-});
-const Pie = new Lang.Class({
-    Name: 'SystemMonitor.Pie',
-    Extends: Graph,
-    _init: function () {
+}
+
+const Pie = class SystemMonitor_Pie extends Graph {
+
+    constructor (width, height) {
+        super(width, height);
         this.mounts = MountsMonitor.get_mounts();
-        MountsMonitor.add_listener(Lang.bind(this, this.update_mounts));
-        this.parent(arguments);
-    },
-    _draw: function () {
+        MountsMonitor.add_listener(this.update_mounts.bind(this));
+    }
+
+    _draw () {
         if (!this.actor.visible) {
             return;
         }
@@ -635,52 +633,49 @@ const Pie = new Lang.Class({
         if (Compat.versionCompare(shell_Version, '3.7.4')) {
             cr.$dispose();
         }
-    },
-    update_mounts: function (mounts) {
+    }
+
+    update_mounts (mounts) {
         this.mounts = mounts;
         this.actor.queue_repaint();
     }
-});
+}
 
-const TipItem = new Lang.Class({
-    Name: 'SystemMonitor.TipItem',
-    Extends: PopupMenu.PopupBaseMenuItem,
+const TipItem = class SystemMonitor_TipItem extends PopupMenu.PopupBaseMenuItem {
 
-    _init: function () {
-        PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
+    constructor () {
+        super();
+        // PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
         this.actor.remove_style_class_name('popup-menu-item');
         this.actor.add_style_class_name('sm-tooltip-item');
     }
-});
+}
 
-const TipMenu = new Lang.Class({
-    Name: 'SystemMonitor.TipMenu',
-    Extends: PopupMenu.PopupMenuBase,
+const TipMenu = class SystemMonitor_TipMenu extends PopupMenu.PopupMenuBase {
 
-    _init: function (sourceActor) {
+    constructor (sourceActor) {
         // PopupMenu.PopupMenuBase.prototype._init.call(this, sourceActor, 'sm-tooltip-box');
-        this.parent(sourceActor, 'sm-tooltip-box');
-        this.actor = new Shell.GenericContainer();
-        this.actor.connect('get-preferred-width',
-            Lang.bind(this, this._boxGetPreferredWidth));
-        this.actor.connect('get-preferred-height',
-            Lang.bind(this, this._boxGetPreferredHeight));
-        this.actor.connect('allocate', Lang.bind(this, this._boxAllocate));
+        super(sourceActor, 'sm-tooltip-box');
+        this.actor = new Clutter.Actor();
+        // this.actor.connect('get-preferred-width',
+        //     this._boxGetPreferredWidth).bind(this);
+        // this.actor.connect('get-preferred-height',
+        //     this._boxGetPreferredHeight.bind(this));
         this.actor.add_actor(this.box);
-    },
-    _boxGetPreferredWidth: function (actor, forHeight, alloc) {
-        // let columnWidths = this.getColumnWidths();
-        // this.setColumnWidths(columnWidths);
-
-        [alloc.min_size, alloc.natural_size] = this.box.get_preferred_width(forHeight);
-    },
-    _boxGetPreferredHeight: function (actor, forWidth, alloc) {
-        [alloc.min_size, alloc.natural_size] = this.box.get_preferred_height(forWidth);
-    },
-    _boxAllocate: function (actor, box, flags) {
-        this.box.allocate(box, flags);
-    },
-    _shift: function () {
+    }
+    // _boxGetPreferredWidth (actor, forHeight, alloc) {
+    //     // let columnWidths = this.getColumnWidths();
+    //     // this.setColumnWidths(columnWidths);
+    //
+    //     [alloc.min_size, alloc.natural_size] = this.box.get_preferred_width(forHeight);
+    // }
+    // _boxGetPreferredHeight (actor, forWidth, alloc) {
+    //     [alloc.min_size, alloc.natural_size] = this.box.get_preferred_height(forWidth);
+    // }
+    // _boxAllocate (actor, box, flags) {
+    //     this.box.allocate(box, flags);
+    // }
+    _shift () {
         // Probably old but works
         let node = this.sourceActor.get_theme_node();
         let contentbox = node.get_content_box(this.sourceActor.get_allocation_box());
@@ -702,8 +697,8 @@ const TipMenu = new Lang.Class({
             tipy = allocation.y1 - height; // If it is at the bottom, place the tooltip above instead of below
         }
         this.actor.set_position(tipx, tipy);
-    },
-    open: function (animate) {
+    }
+    open (animate) {
         if (this.isOpen) {
             return;
         }
@@ -713,26 +708,25 @@ const TipMenu = new Lang.Class({
         this._shift();
         this.actor.raise_top();
         this.emit('open-state-changed', true);
-    },
-    close: function (animate) {
+    }
+    close (animate) {
         this.isOpen = false;
         this.actor.hide();
         this.emit('open-state-changed', false);
     }
-});
+}
 
-const TipBox = new Lang.Class({
-    Name: 'SystemMonitor.TipBox',
+const TipBox = class SystemMonitor_TipBox {
 
-    _init: function () {
+    constructor () {
         this.actor = new St.BoxLayout({reactive: true});
         this.actor._delegate = this;
         this.set_tip(new TipMenu(this.actor));
         this.in_to = this.out_to = 0;
-        this.actor.connect('enter-event', Lang.bind(this, this.on_enter));
-        this.actor.connect('leave-event', Lang.bind(this, this.on_leave));
-    },
-    set_tip: function (tipmenu) {
+        this.actor.connect('enter-event', this.on_enter.bind(this));
+        this.actor.connect('leave-event', this.on_leave.bind(this));
+    }
+    set_tip (tipmenu) {
         if (this.tipmenu) {
             this.tipmenu.destroy();
         }
@@ -741,8 +735,8 @@ const TipBox = new Lang.Class({
             Main.uiGroup.add_actor(this.tipmenu.actor);
             this.hide_tip();
         }
-    },
-    show_tip: function () {
+    }
+    show_tip () {
         if (!this.tipmenu) {
             return;
         }
@@ -751,8 +745,8 @@ const TipBox = new Lang.Class({
             Mainloop.source_remove(this.in_to);
             this.in_to = 0;
         }
-    },
-    hide_tip: function () {
+    }
+    hide_tip () {
         if (!this.tipmenu) {
             return;
         }
@@ -765,8 +759,8 @@ const TipBox = new Lang.Class({
             Mainloop.source_remove(this.in_to);
             this.in_to = 0;
         }
-    },
-    on_enter: function () {
+    }
+    on_enter () {
         let show_tooltip = Schema.get_boolean('show-tooltip');
 
         if (!show_tooltip) {
@@ -779,22 +773,20 @@ const TipBox = new Lang.Class({
         }
         if (!this.in_to) {
             this.in_to = Mainloop.timeout_add(500,
-                Lang.bind(this,
-                    this.show_tip));
+                this.show_tip.bind(this));
         }
-    },
-    on_leave: function () {
+    }
+    on_leave () {
         if (this.in_to) {
             Mainloop.source_remove(this.in_to);
             this.in_to = 0;
         }
         if (!this.out_to) {
             this.out_to = Mainloop.timeout_add(500,
-                Lang.bind(this,
-                    this.hide_tip));
+                this.hide_tip.bind(this));
         }
-    },
-    destroy: function () {
+    }
+    destroy () {
         if (this.in_to) {
             Mainloop.source_remove(this.in_to);
             this.in_to = 0;
@@ -806,23 +798,23 @@ const TipBox = new Lang.Class({
         }
 
         this.actor.destroy();
-    },
-});
+    }
+}
 
-const ElementBase = new Lang.Class({
-    Name: 'SystemMonitor.ElementBase',
-    Extends: TipBox,
+const ElementBase = class SystemMonitor_ElementBase extends TipBox {
 
-    elt: '',
-    item_name: _(''),
-    color_name: [],
-    text_items: [],
-    menu_items: [],
-    menu_visible: true,
+    constructor (properties) {
+        super();
+    	this.elt = '';
+        this.item_name = _('');
+        this.color_name = [];
+        this.text_items = [];
+        this.menu_items = [];
+        this.menu_visible = true;
 
-    _init: function () {
+    	Object.assign(this, properties);
+
         //            TipBox.prototype._init.apply(this, arguments);
-        this.parent(arguments);
         this.vals = [];
         this.tip_labels = [];
         this.tip_vals = [];
@@ -832,70 +824,61 @@ const ElementBase = new Lang.Class({
         for (let color in this.color_name) {
             let name = this.elt + '-' + this.color_name[color] + '-color';
             let clutterColor = color_from_string(Schema.get_string(name));
-            Schema.connect('changed::' + name, Lang.bind(
-                clutterColor, function (schema, key) {
+            Schema.connect('changed::' + name, (schema, key) => {
                     this.clutterColor = color_from_string(Schema.get_string(key));
-                }));
-            Schema.connect('changed::' + name,
-                Lang.bind(this,
-                    function () {
-                        this.chart.actor.queue_repaint();
-                    }));
+                });
+            Schema.connect('changed::' + name, () => {
+                    this.chart.actor.queue_repaint();
+                });
             this.colors.push(clutterColor);
         }
 
         this.chart = new Chart(Schema.get_int(this.elt + '-graph-width'), IconSize, this);
-        Schema.connect('changed::background',
-            Lang.bind(this,
-                function () {
+        Schema.connect('changed::background', () => {
                     this.chart.actor.queue_repaint();
-                }));
+                });
 
         this.actor.visible = Schema.get_boolean(this.elt + '-display');
         Schema.connect(
-            'changed::' + this.elt + '-display',
-            Lang.bind(this,
-                function (schema, key) {
+            'changed::' + this.elt + '-display', (schema, key) => {
                     this.actor.visible = Schema.get_boolean(key);
-                }));
+                });
 
         this.interval = l_limit(Schema.get_int(this.elt + '-refresh-time'));
         this.timeout = Mainloop.timeout_add(
             this.interval,
-            Lang.bind(this, this.update)
+            this.update.bind(this)
         );
         Schema.connect(
             'changed::' + this.elt + '-refresh-time',
-            Lang.bind(this,
-                function (schema, key) {
+                (schema, key) => {
                     Mainloop.source_remove(this.timeout);
                     this.timeout = null;
                     this.interval = l_limit(Schema.get_int(key));
                     this.timeout = Mainloop.timeout_add(
-                        this.interval, Lang.bind(this, this.update));
-                }));
+                        this.interval, this.update.bind(this));
+                });
         Schema.connect('changed::' + this.elt + '-graph-width',
-            Lang.bind(this.chart, this.chart.resize));
+            this.chart.resize.bind(this.chart));
 
         if (this.elt === 'thermal') {
             Schema.connect('changed::thermal-threshold',
-                Lang.bind(this,
-                    function () {
+                    () => {
                         Mainloop.source_remove(this.timeout);
                         this.timeout = null;
                         this.reset_style();
                         this.timeout = Mainloop.timeout_add(
-                            this.interval, Lang.bind(this, this.update));
-                    }));
+                            this.interval, this.update.bind(this));
+                    });
         }
 
         this.label = new St.Label({text: this.elt === 'memory' ? _('mem') : _(this.elt),
             style_class: Style.get('sm-status-label')});
         change_text.call(this);
-        Schema.connect('changed::' + this.elt + '-show-text', Lang.bind(this, change_text));
+        Schema.connect('changed::' + this.elt + '-show-text', change_text.bind(this));
 
         this.menu_visible = Schema.get_boolean(this.elt + '-show-menu');
-        Schema.connect('changed::' + this.elt + '-show-menu', Lang.bind(this, change_menu));
+        Schema.connect('changed::' + this.elt + '-show-menu', change_menu.bind(this));
 
         this.actor.add_actor(this.label);
         this.text_box = new St.BoxLayout();
@@ -907,10 +890,10 @@ const ElementBase = new Lang.Class({
         }
         this.actor.add_actor(this.chart.actor);
         change_style.call(this);
-        Schema.connect('changed::' + this.elt + '-style', Lang.bind(this, change_style));
+        Schema.connect('changed::' + this.elt + '-style', change_style.bind(this));
         this.menu_items = this.create_menu_items();
-    },
-    tip_format: function (unit) {
+    }
+    tip_format (unit) {
         if (typeof (unit) === 'undefined') {
             unit = '%';
         }
@@ -932,13 +915,13 @@ const ElementBase = new Lang.Class({
             tipline.actor.add(this.tip_unit_labels[i]);
             this.tip_vals[i] = 0;
         }
-    },
-    /*        set_tip_unit: function(unit) {
-              for (let i = 0;i < this.tip_unit_labels.length;i++) {
-              this.tip_unit_labels[i].text = unit[i];
-              }
-              },*/
-    update: function () {
+    }
+    //        set_tip_unit: function(unit) {
+    //           for (let i = 0;i < this.tip_unit_labels.length;i++) {
+    //           this.tip_unit_labels[i].text = unit[i];
+    //           }
+    //           }
+    update () {
         if (!this.menu_visible && !this.actor.visible) {
             return false;
         }
@@ -952,11 +935,11 @@ const ElementBase = new Lang.Class({
             this.tip_labels[i].text = this.tip_vals[i].toString();
         }
         return true;
-    },
-    reset_style: function () {
+    }
+    reset_style () {
         this.text_items[0].set_style('color: rgba(255, 255, 255, 1)');
-    },
-    threshold: function () {
+    }
+    threshold () {
         if (Schema.get_int('thermal-threshold')) {
             if (this.temp_over_threshold) {
                 this.text_items[0].set_style('color: rgba(255, 0, 0, 1)');
@@ -964,26 +947,27 @@ const ElementBase = new Lang.Class({
                 this.text_items[0].set_style('color: rgba(255, 255, 255, 1)');
             }
         }
-    },
-    destroy: function () {
+    }
+    destroy () {
         TipBox.prototype.destroy.call(this);
         if (this.timeout) {
             Mainloop.source_remove(this.timeout);
             this.timeout = null;
         }
     }
-});
-const Battery = new Lang.Class({
-    Name: 'SystemMonitor.Battery',
-    Extends: ElementBase,
+}
 
-    elt: 'battery',
-    item_name: _('Battery'),
-    color_name: ['batt0'],
-    max: 100,
+const Battery = class SystemMonitor_Battery extends ElementBase {
 
-    _init: function () {
-        this.item_name = _('Battery');
+    constructor () {
+        super({
+    		elt: 'battery',
+    		item_name: _('Battery'),
+    		color_name: ['batt0'],
+            icon: '. GThemedIcon battery-good-symbolic battery-good'
+    	});
+
+        this.max = 100;
         this.icon_hidden = false;
         this.percentage = 0;
         this.timeString = '-- ';
@@ -991,13 +975,11 @@ const Battery = new Lang.Class({
         if (typeof (this._proxy) === 'undefined') {
             this._proxy = StatusArea.battery._proxy;
         }
-        this.powerSigID = this._proxy.connect('g-properties-changed', Lang.bind(this, this.update_battery));
+        this.powerSigID = this._proxy.connect('g-properties-changed', this.update_battery.bind(this));
 
         // need to specify a default icon, since the contructor completes before UPower callback
-        this.icon = '. GThemedIcon battery-good-symbolic battery-good';
         this.gicon = Gio.icon_new_for_string(this.icon);
 
-        this.parent();
         this.tip_format('%');
 
         this.update_battery();
@@ -1005,13 +987,13 @@ const Battery = new Lang.Class({
         // this.hide_system_icon();
         this.update();
 
-        // Schema.connect('changed::' + this.elt + '-hidesystem', Lang.bind(this, this.hide_system_icon));
-        Schema.connect('changed::' + this.elt + '-time', Lang.bind(this, this.update_tips));
-    },
-    refresh: function () {
+        // Schema.connect('changed::' + this.elt + '-hidesystem', this.hide_system_icon.bind(this));
+        Schema.connect('changed::' + this.elt + '-time', this.update_tips.bind(this));
+    }
+    refresh () {
         // do nothing here?
-    },
-    update_battery: function () {
+    }
+    update_battery () {
         // callback function for when battery stats updated.
         let battery_found = false;
         let isBattery = false;
@@ -1031,7 +1013,7 @@ const Battery = new Lang.Class({
                 build_menu_info();
             }
         } else {
-            this._proxy.GetDevicesRemote(Lang.bind(this, function (devices, error) {
+            this._proxy.GetDevicesRemote((devices, error) => {
                 if (error) {
                     log('[System monitor] Power proxy error: ' + error);
                     this.actor.hide();
@@ -1063,10 +1045,10 @@ const Battery = new Lang.Class({
                     this.menu_visible = false;
                     build_menu_info();
                 }
-            }));
+            });
         }
-    },
-    update_battery_value: function (seconds, percentage, icon) {
+    }
+    update_battery_value (seconds, percentage, icon) {
         if (seconds > 60) {
             let time = Math.round(seconds / 60);
             let minutes = time % 60;
@@ -1085,8 +1067,8 @@ const Battery = new Lang.Class({
             this.menu_visible = true;
             build_menu_info();
         }
-    },
-    hide_system_icon: function (override) {
+    }
+    hide_system_icon (override) {
         let value = Schema.get_boolean(this.elt + '-hidesystem');
         if (!override) {
             value = false;
@@ -1118,8 +1100,8 @@ const Battery = new Lang.Class({
             this.icon_hidden = false;
             // Main.panel._updatePanel('right');
         }
-    },
-    get_battery_unit: function () {
+    }
+    get_battery_unit () {
         let unitString;
         let value = Schema.get_boolean(this.elt + '-time');
 
@@ -1130,8 +1112,8 @@ const Battery = new Lang.Class({
         }
 
         return unitString;
-    },
-    update_tips: function () {
+    }
+    update_tips () {
         let unitString = this.get_battery_unit();
 
         if (Schema.get_boolean(this.elt + '-display')) {
@@ -1142,8 +1124,8 @@ const Battery = new Lang.Class({
         }
 
         this.update();
-    },
-    _apply: function () {
+    }
+    _apply () {
         let displayString;
         let value = Schema.get_boolean(this.elt + '-time');
         if (value) {
@@ -1160,8 +1142,8 @@ const Battery = new Lang.Class({
         }
         this.vals = [this.percentage];
         this.tip_vals[0] = Math.round(this.percentage);
-    },
-    create_text_items: function () {
+    }
+    create_text_items () {
         return [
             new St.Icon({
                 gicon: Gio.icon_new_for_string(this.icon),
@@ -1175,8 +1157,8 @@ const Battery = new Lang.Class({
                 style_class: Style.get('sm-perc-label'),
                 y_align: Clutter.ActorAlign.CENTER})
         ];
-    },
-    create_menu_items: function () {
+    }
+    create_menu_items () {
         return [
             new St.Label({
                 text: '',
@@ -1185,24 +1167,24 @@ const Battery = new Lang.Class({
                 text: this.get_battery_unit(),
                 style_class: Style.get('sm-label')})
         ];
-    },
-    destroy: function () {
+    }
+    destroy () {
         ElementBase.prototype.destroy.call(this);
         this._proxy.disconnect(this.powerSigID);
     }
-});
+}
 
-const Cpu = new Lang.Class({
-    Name: 'SystemMonitor.Cpu',
-    Extends: ElementBase,
+const Cpu = class SystemMonitor_Cpu extends ElementBase {
 
-    elt: 'cpu',
-    item_name: _('CPU'),
-    color_name: ['user', 'system', 'nice', 'iowait', 'other'],
-    max: 100,
-    cpuid: -1, // cpuid is -1 when all cores are displayed in the same graph
+    constructor (cpuid) {
+        super({
+            elt: 'cpu',
+            item_name: _('CPU'),
+            color_name: ['user', 'system', 'nice', 'iowait', 'other'],
+            cpuid: -1 // cpuid is -1 when all cores are displayed in the same graph
+    	});
+        this.max = 100;
 
-    _init: function (cpuid) {
         this.cpuid = cpuid;
         this.gtop = new GTop.glibtop_cpu();
         this.last = [0, 0, 0, 0, 0];
@@ -1223,11 +1205,10 @@ const Cpu = new Lang.Class({
             this.item_name += ' ' + (cpuid + 1);
         } // append cpu number to cpu name in popup
         // ElementBase.prototype._init.call(this);
-        this.parent()
         this.tip_format();
         this.update();
-    },
-    refresh: function () {
+    }
+    refresh () {
         GTop.glibtop_get_cpu(this.gtop);
         // display global cpu usage on 1 graph
         if (this.cpuid === -1) {
@@ -1273,43 +1254,41 @@ const Cpu = new Lang.Class({
             }
         }
 
-        /*
-        GTop.glibtop_get_cpu(this.gtop);
-        // display global cpu usage on 1 graph
-        if (this.cpuid == -1) {
-            this.current[0] = this.gtop.user;
-            this.current[1] = this.gtop.sys;
-            this.current[2] = this.gtop.nice;
-            this.current[3] = this.gtop.idle;
-            this.current[4] = this.gtop.iowait;
-        } else {
-            // display cpu usage for given core
-            this.current[0] = this.gtop.xcpu_user[this.cpuid];
-            this.current[1] = this.gtop.xcpu_sys[this.cpuid];
-            this.current[2] = this.gtop.xcpu_nice[this.cpuid];
-            this.current[3] = this.gtop.xcpu_idle[this.cpuid];
-            this.current[4] = this.gtop.xcpu_iowait[this.cpuid];
-        }
-
-        let delta = 0;
-        if (this.cpuid == -1)
-            delta = (this.gtop.total - this.last_total)/(100*this.total_cores);
-        else
-            delta = (this.gtop.xcpu_total[this.cpuid] - this.last_total)/100;
-
-        if (delta > 0) {
-            for (let i = 0;i < 5;i++) {
-                this.usage[i] = Math.round((this.current[i] - this.last[i])/delta);
-                this.last[i] = this.current[i];
-            }
-            if (this.cpuid == -1)
-                this.last_total = this.gtop.total;
-            else
-                this.last_total = this.gtop.xcpu_total[this.cpuid];
-        }
-        */
-    },
-    _apply: function () {
+        // GTop.glibtop_get_cpu(this.gtop);
+        // // display global cpu usage on 1 graph
+        // if (this.cpuid == -1) {
+        //     this.current[0] = this.gtop.user;
+        //     this.current[1] = this.gtop.sys;
+        //     this.current[2] = this.gtop.nice;
+        //     this.current[3] = this.gtop.idle;
+        //     this.current[4] = this.gtop.iowait;
+        // } else {
+        //     // display cpu usage for given core
+        //     this.current[0] = this.gtop.xcpu_user[this.cpuid];
+        //     this.current[1] = this.gtop.xcpu_sys[this.cpuid];
+        //     this.current[2] = this.gtop.xcpu_nice[this.cpuid];
+        //     this.current[3] = this.gtop.xcpu_idle[this.cpuid];
+        //     this.current[4] = this.gtop.xcpu_iowait[this.cpuid];
+        // }
+        //
+        // let delta = 0;
+        // if (this.cpuid == -1)
+        //     delta = (this.gtop.total - this.last_total)/(100*this.total_cores);
+        // else
+        //     delta = (this.gtop.xcpu_total[this.cpuid] - this.last_total)/100;
+        //
+        // if (delta > 0) {
+        //     for (let i = 0;i < 5;i++) {
+        //         this.usage[i] = Math.round((this.current[i] - this.last[i])/delta);
+        //         this.last[i] = this.current[i];
+        //     }
+        //     if (this.cpuid == -1)
+        //         this.last_total = this.gtop.total;
+        //     else
+        //         this.last_total = this.gtop.xcpu_total[this.cpuid];
+        // }
+    }
+    _apply () {
         let percent = 0;
         if (this.cpuid === -1) {
             percent = Math.round(((100 * this.total_cores) - this.usage[3]) /
@@ -1330,9 +1309,9 @@ const Cpu = new Lang.Class({
         for (let i = 0; i < 5; i++) {
             this.tip_vals[i] = Math.round(this.vals[i]);
         }
-    },
+    }
 
-    get_cores: function () {
+    get_cores () {
         // Getting xcpu_total makes gjs 1.29.18 segfault
         // let cores = 0;
         // GTop.glibtop_get_cpu(this.gtop);
@@ -1343,8 +1322,8 @@ const Cpu = new Lang.Class({
         // }
         // return cores;
         return 1;
-    },
-    create_text_items: function () {
+    }
+    create_text_items () {
         return [
             new St.Label({
                 text: '',
@@ -1354,8 +1333,8 @@ const Cpu = new Lang.Class({
                 text: '%', style_class: Style.get('sm-perc-label'),
                 y_align: Clutter.ActorAlign.CENTER})
         ];
-    },
-    create_menu_items: function () {
+    }
+    create_menu_items () {
         return [
             new St.Label({
                 text: '',
@@ -1365,10 +1344,10 @@ const Cpu = new Lang.Class({
                 style_class: Style.get('sm-label')})
         ];
     }
-});
+}
 
-/* Check if one graph per core must be displayed and create the
-   appropriate number of cpu items */
+// Check if one graph per core must be displayed and create the
+//    appropriate number of cpu items
 function createCpus() {
     let array = [];
     let numcores = 1;
@@ -1399,29 +1378,26 @@ function createCpus() {
     return array;
 }
 
-const Disk = new Lang.Class({
-    Name: 'SystemMonitor.Disk',
-    Extends: ElementBase,
+const Disk = class SystemMonitor_Disk extends ElementBase {
 
-    elt: 'disk',
-    item_name: _('Disk'),
-    color_name: ['read', 'write'],
-
-    _init: function () {
-        this.item_name = _('Disk');
+    constructor () {
+        super({
+        	elt: 'disk',
+            item_name: _('Disk'),
+            color_name: ['read', 'write']
+        });
         this.mounts = MountsMonitor.get_mounts();
-        MountsMonitor.add_listener(Lang.bind(this, this.update_mounts));
+        MountsMonitor.add_listener(this.update_mounts.bind(this));
         this.last = [0, 0];
         this.usage = [0, 0];
         this.last_time = 0;
-        this.parent()
         this.tip_format(_('MiB/s'));
         this.update();
-    },
-    update_mounts: function (mounts) {
+    }
+    update_mounts (mounts) {
         this.mounts = mounts;
-    },
-    refresh: function () {
+    }
+    refresh () {
         let accum = [0, 0];
         let lines = Shell.get_file_contents_utf8_sync('/proc/diskstats').split('\n');
 
@@ -1444,8 +1420,8 @@ const Disk = new Lang.Class({
             }
         }
         this.last_time = time;
-    },
-    _apply: function () {
+    }
+    _apply () {
         this.vals = this.usage.slice();
         for (let i = 0; i < 2; i++) {
             if (this.usage[i] < 10) {
@@ -1457,8 +1433,8 @@ const Disk = new Lang.Class({
         this.tip_vals = [this.usage[0], this.usage[1]];
         this.menu_items[0].text = this.text_items[1].text = this.tip_vals[0].toLocaleString(Locale);
         this.menu_items[3].text = this.text_items[4].text = this.tip_vals[1].toLocaleString(Locale);
-    },
-    create_text_items: function () {
+    }
+    create_text_items () {
         return [
             new St.Label({
                 text: _('R'),
@@ -1483,8 +1459,8 @@ const Disk = new Lang.Class({
                 style_class: Style.get('sm-disk-unit-label'),
                 y_align: Clutter.ActorAlign.CENTER})
         ];
-    },
-    create_menu_items: function () {
+    }
+    create_menu_items () {
         return [
             new St.Label({
                 text: '',
@@ -1505,29 +1481,27 @@ const Disk = new Lang.Class({
                 text: _(' W'),
                 style_class: Style.get('sm-label')})
         ];
-    },
-});
+    }
+}
 
-const Freq = new Lang.Class({
-    Name: 'SystemMonitor.Freq',
-    Extends: ElementBase,
+const Freq = class SystemMonitor_Freq extends ElementBase {
 
-    elt: 'freq',
-    item_name: _('Freq'),
-    color_name: ['freq'],
-    _init: function () {
-        this.item_name = _('Freq');
+    constructor () {
+        super({
+            elt: 'freq',
+            item_name: _('Freq'),
+            color_name: ['freq']
+        });
         this.freq = 0;
-        this.parent();
         this.tip_format('MHz');
         this.update();
-    },
-    refresh: function () {
+    }
+    refresh () {
         let total_frequency = 0;
         let num_cpus = GTop.glibtop_get_sysinfo().ncpu;
         let i = 0;
         let file = Gio.file_new_for_path(`/sys/devices/system/cpu/cpu${i}/cpufreq/scaling_cur_freq`);
-        file.load_contents_async(null, Lang.bind(this, function cb (source, result) {
+        file.load_contents_async(null, (source, result) => {
             let as_r = source.load_contents_finish(result);
             total_frequency += parseInt(as_r[1]);
 
@@ -1535,11 +1509,11 @@ const Freq = new Lang.Class({
                 this.freq = Math.round(total_frequency / num_cpus / 1000);
             } else {
                 file = Gio.file_new_for_path(`/sys/devices/system/cpu/cpu${i}/cpufreq/scaling_cur_freq`);
-                file.load_contents_async(null, Lang.bind(this, cb));
+                file.load_contents_async(null, cb.bind(this));
             }
-        }));
-    },
-    _apply: function () {
+        });
+    }
+    _apply () {
         let value = this.freq.toString();
         this.text_items[0].text = value + ' ';
         this.vals[0] = value;
@@ -1549,16 +1523,16 @@ const Freq = new Lang.Class({
         } else {
             this.menu_items[0].text = this._pad(value, 4);
         }
-    },
+    }
     // pad a string with leading spaces
-    _pad: function (number, length) {
+    _pad (number, length) {
         var str = '' + number;
         while (str.length < length) {
             str = ' ' + str;
         }
         return str;
-    },
-    create_text_items: function () {
+    }
+    create_text_items () {
         return [
             new St.Label({
                 text: '',
@@ -1568,8 +1542,8 @@ const Freq = new Lang.Class({
                 text: 'MHz', style_class: Style.get('sm-perc-label'),
                 y_align: Clutter.ActorAlign.CENTER})
         ];
-    },
-    create_menu_items: function () {
+    }
+    create_menu_items () {
         return [
             new St.Label({
                 text: '',
@@ -1579,19 +1553,18 @@ const Freq = new Lang.Class({
                 style_class: Style.get('sm-label')})
         ];
     }
-});
+}
 
-const Mem = new Lang.Class({
-    Name: 'SystemMonitor.Mem',
-    Extends: ElementBase,
+const Mem = class SystemMonitor_Mem extends ElementBase{
 
-    elt: 'memory',
-    item_name: _('Memory'),
-    color_name: ['program', 'buffer', 'cache'],
-    max: 1,
+    constructor () {
+        super({
+            elt: 'memory',
+            item_name: _('Memory'),
+            color_name: ['program', 'buffer', 'cache']
+        });
+        this.max = 1;
 
-    _init: function () {
-        this.item_name = _('Memory');
         this.gtop = new GTop.glibtop_mem();
         this.mem = [0, 0, 0];
 
@@ -1606,11 +1579,10 @@ const Mem = new Lang.Class({
             this._unitConversion *= 1024 / this._decimals;
         }
 
-        this.parent();
         this.tip_format();
         this.update();
-    },
-    refresh: function () {
+    }
+    refresh () {
         GTop.glibtop_get_mem(this.gtop);
         if (this.useGiB) {
             this.mem[0] = Math.round(this.gtop.user / this._unitConversion);
@@ -1627,8 +1599,8 @@ const Mem = new Lang.Class({
             this.mem[2] = Math.round(this.gtop.cached / this._unitConversion);
             this.total = Math.round(this.gtop.total / this._unitConversion);
         }
-    },
-    _pad: function (number) {
+    }
+    _pad (number) {
         if (this.useGiB) {
             if (number < 1) {
                 // examples: 0.01, 0.10, 0.88
@@ -1639,8 +1611,8 @@ const Mem = new Lang.Class({
         }
 
         return number;
-    },
-    _apply: function () {
+    }
+    _apply () {
         if (this.total === 0) {
             this.vals = this.tip_vals = [0, 0, 0];
         } else {
@@ -1658,8 +1630,8 @@ const Mem = new Lang.Class({
             this.menu_items[3].text = this._pad(this.mem[0]).toLocaleString(Locale) +
                 '/' + this._pad(this.total).toLocaleString(Locale);
         }
-    },
-    create_text_items: function () {
+    }
+    create_text_items () {
         return [
             new St.Label({
                 text: '',
@@ -1669,8 +1641,8 @@ const Mem = new Lang.Class({
                 text: '%', style_class: Style.get('sm-perc-label'),
                 y_align: Clutter.ActorAlign.CENTER})
         ];
-    },
-    create_menu_items: function () {
+    }
+    create_menu_items () {
         let unit = _('MiB');
         if (this.useGiB) {
             unit = _('GiB');
@@ -1692,19 +1664,17 @@ const Mem = new Lang.Class({
                 style_class: Style.get('sm-label')})
         ];
     }
-});
+}
 
-const Net = new Lang.Class({
-    Name: 'SystemMonitor.Net',
-    Extends: ElementBase,
+const Net = class SystemMonitor_Net extends ElementBase {
 
-    elt: 'net',
-    item_name: _('Net'),
-    color_name: ['down', 'downerrors', 'up', 'uperrors', 'collisions'],
-    speed_in_bits: false,
-
-    _init: function () {
-        this.item_name = _('Net');
+    constructor () {
+        super({
+            elt: 'net',
+            item_name: _('Net'),
+            color_name: ['down', 'downerrors', 'up', 'uperrors', 'collisions']
+        });
+        this.speed_in_bits = false;
         this.ifs = [];
         this.client = libnm_glib ? NM.Client.new() : NM.Client.new(null);
         this.update_iface_list();
@@ -1725,25 +1695,24 @@ const Net = new Lang.Class({
         this.last = [0, 0, 0, 0, 0];
         this.usage = [0, 0, 0, 0, 0];
         this.last_time = 0;
-        this.parent();
         this.tip_format([_('KiB/s'), '/s', _('KiB/s'), '/s', '/s']);
         this.update_units();
-        Schema.connect('changed::' + this.elt + '-speed-in-bits', Lang.bind(this, this.update_units));
+        Schema.connect('changed::' + this.elt + '-speed-in-bits', this.update_units.bind(this));
         try {
             let iface_list = this.client.get_devices();
             this.NMsigID = [];
             for (let j = 0; j < iface_list.length; j++) {
-                this.NMsigID[j] = iface_list[j].connect('state-changed', Lang.bind(this, this.update_iface_list));
+                this.NMsigID[j] = iface_list[j].connect('state-changed', this.update_iface_list.bind(this));
             }
         } catch (e) {
             global.logError('Please install Network Manager Gobject Introspection Bindings: ' + e);
         }
         this.update();
-    },
-    update_units: function () {
+    }
+    update_units () {
         this.speed_in_bits = Schema.get_boolean(this.elt + '-speed-in-bits');
-    },
-    update_iface_list: function () {
+    }
+    update_iface_list () {
         try {
             this.ifs = [];
             let iface_list = this.client.get_devices();
@@ -1755,8 +1724,8 @@ const Net = new Lang.Class({
         } catch (e) {
             global.logError('Please install Network Manager Gobject Introspection Bindings');
         }
-    },
-    refresh: function () {
+    }
+    refresh () {
         let accum = [0, 0, 0, 0, 0];
 
         for (let ifn in this.ifs) {
@@ -1778,18 +1747,18 @@ const Net = new Lang.Class({
             }
         }
         this.last_time = time;
-    },
+    }
 
     // pad a string with leading spaces
-    _pad: function (number, length) {
+    _pad (number, length) {
         var str = '' + number;
         while (str.length < length) {
             str = ' ' + str;
         }
         return str;
-    },
+    }
 
-    _apply: function () {
+    _apply () {
         this.tip_vals = this.usage;
         if (this.speed_in_bits) {
             this.tip_vals[0] = Math.round(this.tip_vals[0] * 8.192);
@@ -1836,8 +1805,8 @@ const Net = new Lang.Class({
             this.menu_items[0].text = this.text_items[1].text = this._pad(this.tip_vals[0].toString(), 4);
             this.menu_items[3].text = this.text_items[4].text = this._pad(this.tip_vals[2].toString(), 4);
         }
-    },
-    create_text_items: function () {
+    }
+    create_text_items () {
         return [
             new St.Icon({
                 icon_size: 2 * IconSize / 3 * Style.iconsize(),
@@ -1862,8 +1831,8 @@ const Net = new Lang.Class({
                 style_class: Style.get('sm-net-unit-label'),
                 y_align: Clutter.ActorAlign.CENTER})
         ];
-    },
-    create_menu_items: function () {
+    }
+    create_menu_items () {
         return [
             new St.Label({
                 text: '',
@@ -1885,19 +1854,17 @@ const Net = new Lang.Class({
                 style_class: Style.get('sm-label')})
         ];
     }
-});
+}
 
-const Swap = new Lang.Class({
-    Name: 'SystemMonitor.Swap',
-    Extends: ElementBase,
+const Swap = class SystemMonitor_Swap extends ElementBase {
 
-    elt: 'swap',
-    item_name: _('Swap'),
-    color_name: ['used'],
-    max: 1,
-
-    _init: function () {
-        this.item_name = _('Swap');
+    constructor () {
+        super({
+            elt: 'swap',
+            item_name: _('Swap'),
+            color_name: ['used']
+        });
+        this.max = 1;
         this.gtop = new GTop.glibtop_swap();
 
         GTop.glibtop_get_swap(this.gtop);
@@ -1911,11 +1878,10 @@ const Swap = new Lang.Class({
             this._unitConversion *= 1024 / this._decimals;
         }
 
-        this.parent()
         this.tip_format();
         this.update();
-    },
-    refresh: function () {
+    }
+    refresh () {
         GTop.glibtop_get_swap(this.gtop);
         if (this.useGiB) {
             this.swap = Math.round(this.gtop.used / this._unitConversion);
@@ -1926,8 +1892,8 @@ const Swap = new Lang.Class({
             this.swap = Math.round(this.gtop.used / this._unitConversion);
             this.total = Math.round(this.gtop.total / this._unitConversion);
         }
-    },
-    _pad: function (number) {
+    }
+    _pad (number) {
         if (this.useGiB) {
             if (number < 1) {
                 // examples: 0.01, 0.10, 0.88
@@ -1938,8 +1904,8 @@ const Swap = new Lang.Class({
         }
 
         return number;
-    },
-    _apply: function () {
+    }
+    _apply () {
         if (this.total === 0) {
             this.vals = this.tip_vals = [0];
         } else {
@@ -1955,9 +1921,9 @@ const Swap = new Lang.Class({
             this.menu_items[3].text = this._pad(this.swap).toLocaleString(Locale) +
                 '/' + this._pad(this.total).toLocaleString(Locale);
         }
-    },
+    }
 
-    create_text_items: function () {
+    create_text_items () {
         return [
             new St.Label({
                 text: '',
@@ -1968,8 +1934,8 @@ const Swap = new Lang.Class({
                 style_class: Style.get('sm-perc-label'),
                 y_align: Clutter.ActorAlign.CENTER})
         ];
-    },
-    create_menu_items: function () {
+    }
+    create_menu_items () {
         let unit = 'MiB';
         if (this.useGiB) {
             unit = 'GiB';
@@ -1992,45 +1958,45 @@ const Swap = new Lang.Class({
                 style_class: Style.get('sm-label')})
         ];
     }
-});
+}
 
-const Thermal = new Lang.Class({
-    Name: 'SystemMonitor.Thermal',
-    Extends: ElementBase,
+const Thermal = class SystemMonitor_Thermal extends ElementBase {
 
-    elt: 'thermal',
-    item_name: _('Thermal'),
-    color_name: ['tz0'],
-    max: 100,
-    _init: function () {
+    constructor () {
+        super({
+            elt: 'thermal',
+            item_name: _('Thermal'),
+            color_name: ['tz0']
+        });
+        this.max = 100;
+
         this.item_name = _('Thermal');
         this.temperature = '-- ';
         this.fahrenheit_unit = Schema.get_boolean(this.elt + '-fahrenheit-unit');
         this.display_error = true;
-        this.parent()
         this.tip_format(this.temperature_symbol());
-        Schema.connect('changed::' + this.elt + '-sensor-file', Lang.bind(this, this.refresh));
+        Schema.connect('changed::' + this.elt + '-sensor-file', this.refresh.bind(this));
         this.update();
-    },
-    refresh: function () {
+    }
+    refresh () {
         let sfile = Schema.get_string(this.elt + '-sensor-file');
         if (GLib.file_test(sfile, 1 << 4)) {
             let file = Gio.file_new_for_path(sfile);
-            file.load_contents_async(null, Lang.bind(this, function (source, result) {
+            file.load_contents_async(null, (source, result) => {
                 let as_r = source.load_contents_finish(result)
                 this.temperature = Math.round(parseInt(as_r[1]) / 1000);
                 if (this.fahrenheit_unit) {
                     this.temperature = Math.round(this.temperature * 1.8 + 32);
                 }
-            }));
+            });
         } else if (this.display_error) {
             global.logError('error reading: ' + sfile);
             this.display_error = false;
         }
 
         this.fahrenheit_unit = Schema.get_boolean(this.elt + '-fahrenheit-unit');
-    },
-    _apply: function () {
+    }
+    _apply () {
         this.text_items[0].text = this.menu_items[0].text = this.temperature_text();
         // Making it looks better in chart.
         // this.vals = [this.temperature / 100];
@@ -2039,8 +2005,8 @@ const Thermal = new Lang.Class({
         this.tip_vals[0] = this.temperature_text();
         this.menu_items[1].text = this.temperature_symbol();
         this.tip_unit_labels[0].text = _(this.temperature_symbol());
-    },
-    create_text_items: function () {
+    }
+    create_text_items () {
         return [
             new St.Label({
                 text: '',
@@ -2051,8 +2017,8 @@ const Thermal = new Lang.Class({
                 style_class: Style.get('sm-temp-label'),
                 y_align: Clutter.ActorAlign.CENTER})
         ];
-    },
-    create_menu_items: function () {
+    }
+    create_menu_items () {
         return [
             new St.Label({
                 text: '',
@@ -2061,52 +2027,49 @@ const Thermal = new Lang.Class({
                 text: this.temperature_symbol(),
                 style_class: Style.get('sm-label')})
         ];
-    },
-    temperature_text: function () {
+    }
+    temperature_text () {
         return this.temperature.toString();
-    },
-    temperature_symbol: function () {
+    }
+    temperature_symbol () {
         return this.fahrenheit_unit ? '\u2109' : '\u2103';
     }
-});
+}
 
-const Fan = new Lang.Class({
-    Name: 'SystemMonitor.Fan',
-    Extends: ElementBase,
+const Fan = class SystemMonitor_Fan extends ElementBase {
 
-    elt: 'fan',
-    item_name: _('Fan'),
-    color_name: ['fan0'],
-
-    _init: function () {
-        this.item_name = _('Fan');
+    constructor () {
+        super({
+            elt: 'fan',
+            item_name: _('Fan'),
+            color_name: ['fan0']
+        });
         this.rpm = 0;
         this.display_error = true;
-        this.parent()
         this.tip_format(_('rpm'));
-        Schema.connect('changed::' + this.elt + '-sensor-file', Lang.bind(this, this.refresh));
+        Schema.connect('changed::' + this.elt + '-sensor-file', this.refresh.bind(this));
         this.update();
-    },
-    refresh: function () {
+    }
+    refresh () {
         let sfile = Schema.get_string(this.elt + '-sensor-file');
         if (GLib.file_test(sfile, 1 << 4)) {
             let file = Gio.file_new_for_path(sfile);
-            file.load_contents_async(null, Lang.bind(this, function (source, result) {
+            file.load_contents_async(null, (source, result) => {
                 let as_r = source.load_contents_finish(result)
                 this.rpm = parseInt(as_r[1]);
-            }));
+            });
         } else if (this.display_error) {
             global.logError('error reading: ' + sfile);
             this.display_error = false;
         }
-    },
-    _apply: function () {
+    }
+    _apply () {
         this.text_items[0].text = this.rpm.toString();
         this.menu_items[0].text = this.rpm.toString();
         this.vals = [this.rpm / 10];
         this.tip_vals[0] = this.rpm;
-    },
-    create_text_items: function () {
+    }
+    create_text_items () {
         return [
             new St.Label({
                 text: '',
@@ -2116,8 +2079,8 @@ const Fan = new Lang.Class({
                 text: _('rpm'), style_class: Style.get('sm-unit-label'),
                 y_align: Clutter.ActorAlign.CENTER})
         ];
-    },
-    create_menu_items: function () {
+    }
+    create_menu_items () {
         return [
             new St.Label({
                 text: '',
@@ -2127,26 +2090,25 @@ const Fan = new Lang.Class({
                 style_class: Style.get('sm-label')})
         ];
     }
-});
+}
 
-const Gpu = new Lang.Class({
-    Name: 'SystemMonitor.Gpu',
-    Extends: ElementBase,
+const Gpu = class SystemMonitor_Gpu extends ElementBase{
 
-    elt: 'gpu',
-    item_name: _('GPU'),
-    color_name: ['used'],
-    max: 100,
+    constructor () {
+        super({
+            elt: 'gpu',
+            item_name: _('GPU'),
+            color_name: ['used']
+        });
+        this.max = 100;
 
-    _init: function () {
         this.item_name = _('GPU');
         this.mem = 0;
         this.total = 0;
-        this.parent()
         this.tip_format();
         this.update();
-    },
-    _unit: function (total) {
+    }
+    _unit (total) {
         this.total = total;
         let threshold = 4 * 1024; // In MiB
         this.useGiB = false;
@@ -2156,8 +2118,8 @@ const Gpu = new Lang.Class({
             this.useGiB = true;
             this._unitConversion *= 1024 / this._decimals;
         }
-    },
-    refresh: function () {
+    }
+    refresh () {
         // Run asynchronously, to avoid shell freeze
         try {
             let path = Me.dir.get_path();
@@ -2188,13 +2150,13 @@ const Gpu = new Lang.Class({
             this._process_sourceId = GLib.child_watch_add(
                 0,
                 pid,
-                Lang.bind(this, this._readTemperature)
+                this._readTemperature.bind(this)
             );
         } catch (err) {
             // Deal with the error
         }
-    },
-    _readTemperature: function () {
+    }
+    _readTemperature () {
         let usage = [];
         let out, size;
         if (this._process_stream) {
@@ -2225,14 +2187,14 @@ const Gpu = new Lang.Class({
         }
 
         this._endProcess();
-    },
-    _endProcess: function () {
+    }
+    _endProcess () {
         if (this._process_stream) {
             this._process_stream.close(null);
             this._process_stream = null;
         }
-    },
-    _pad: function (number) {
+    }
+    _pad (number) {
         if (this.useGiB) {
             if (number < 1) {
                 // examples: 0.01, 0.10, 0.88
@@ -2243,8 +2205,8 @@ const Gpu = new Lang.Class({
         }
 
         return number;
-    },
-    _apply: function () {
+    }
+    _apply () {
         if (this.total === 0) {
             this.vals = [0];
             this.tip_vals = [0];
@@ -2261,8 +2223,8 @@ const Gpu = new Lang.Class({
             this.menu_items[3].text = this._pad(this.mem).toLocaleString() +
                 '/' + this._pad(this.total).toLocaleString();
         }
-    },
-    create_text_items: function () {
+    }
+    create_text_items () {
         return [
             new St.Label({
                 text: '',
@@ -2273,8 +2235,8 @@ const Gpu = new Lang.Class({
                 style_class: Style.get('sm-perc-label'),
                 y_align: Clutter.ActorAlign.CENTER})
         ];
-    },
-    create_menu_items: function () {
+    }
+    create_menu_items () {
         let unit = _('MiB');
         if (this.useGiB) {
             unit = _('GiB');
@@ -2297,27 +2259,24 @@ const Gpu = new Lang.Class({
                 style_class: Style.get('sm-label')})
         ];
     }
-});
+}
 
-const Icon = new Lang.Class({
-    Name: 'SystemMonitor.Icon',
+const Icon = class SystemMonitor_Icon {
 
-    _init: function () {
+    constructor () {
         this.actor = new St.Icon({icon_name: 'utilities-system-monitor-symbolic',
             style_class: 'system-status-icon'});
         this.actor.visible = Schema.get_boolean('icon-display');
         Schema.connect(
             'changed::icon-display',
-            Lang.bind(this,
-                function () {
-                    this.actor.visible = Schema.get_boolean('icon-display');
-                })
+            () => {
+                this.actor.visible = Schema.get_boolean('icon-display');
+            }
         );
     }
-});
+}
 
-
-var init = function () {
+function init() {
     log('[System monitor] applet init from ' + extension.path);
 
     Convenience.initTranslations();
@@ -2329,9 +2288,10 @@ var init = function () {
     }
 
     IconSize = Math.round(Panel.PANEL_ICON_SIZE * 4 / 5);
-};
+}
 
-var enable = function () {
+function enable () {
+
     log('[System monitor] applet enabling');
     Schema = Convenience.getSettings();
 
@@ -2347,7 +2307,7 @@ var enable = function () {
 
         let dialog_timeout = Mainloop.timeout_add_seconds(
             1,
-            function () {
+            () => {
                 Main.__sm.smdialog.open();
                 Mainloop.source_remove(dialog_timeout);
                 return true;
@@ -2382,12 +2342,11 @@ var enable = function () {
         Main.__sm.elts.push(new Disk());
         Main.__sm.elts.push(new Gpu());
         Main.__sm.elts.push(new Thermal());
-        Main.__sm.elts.push(new Fan());
+	    Main.__sm.elts.push(new Fan());
         Main.__sm.elts.push(new Battery());
 
-        let tray = Main.__sm.tray;
+	    let tray = Main.__sm.tray;
         let elts = Main.__sm.elts;
-
 
         if (Schema.get_boolean('move-clock')) {
             let dateMenu;
@@ -2403,10 +2362,9 @@ var enable = function () {
             tray.clockMoved = true;
         }
 
-        Schema.connect('changed::background', Lang.bind(
-            this, function (schema, key) {
+        Schema.connect('changed::background', (schema, key) => {
                 Background = color_from_string(Schema.get_string(key));
-            }));
+            });
         if (!Compat.versionCompare(shell_Version, '3.5.5')) {
             StatusArea.systemMonitor = tray;
             panel.insert_child_at_index(tray.actor, 1);
@@ -2456,7 +2414,7 @@ var enable = function () {
 
                     menu_timeout = Mainloop.timeout_add_seconds(
                         5,
-                        function () {
+                        () => {
                             Main.__sm.pie.actor.queue_repaint();
                             return true;
                         });
@@ -2471,13 +2429,13 @@ var enable = function () {
         let _gsmPrefs = _appSys.lookup_app('gnome-shell-extension-prefs.desktop');
         let item;
         item = new PopupMenu.PopupMenuItem(_('System Monitor...'));
-        item.connect('activate', function () {
+        item.connect('activate', () => {
             _gsmApp.activate();
         });
         tray.menu.addMenuItem(item);
 
         item = new PopupMenu.PopupMenuItem(_('Preferences...'));
-        item.connect('activate', function () {
+        item.connect('activate', () => {
             if (_gsmPrefs.get_state() === _gsmPrefs.SHELL_APP_STATE_RUNNING) {
                 _gsmPrefs.activate();
             } else {
@@ -2493,11 +2451,10 @@ var enable = function () {
             Main.panel._menus.addMenu(tray.menu);
         }
     }
-
     log('[System monitor] applet enabling done');
-};
+}
 
-var disable = function () {
+function disable () {
     // restore clock
     if (Main.__sm.tray.clockMoved) {
         let dateMenu;
@@ -2542,5 +2499,6 @@ var disable = function () {
         Main.__sm.tray.actor.destroy();
     }
     Main.__sm = null;
+
     log('[System monitor] applet disable');
-};
+}

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1490,7 +1490,7 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
         var that = this;
         file.load_contents_async(null, function cb (source, result) {
             let as_r = source.load_contents_finish(result);
-            total_frequency += parseInt(as_r[1]);
+            total_frequency += parseInt(ByteArray.toString(as_r[1]));
 
             if (++i >= num_cpus) {
                 that.freq = Math.round(total_frequency / num_cpus / 1000);

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -37,6 +37,8 @@ var Power = imports.ui.status.power;
 // const System = imports.system;
 var ModalDialog = imports.ui.modalDialog;
 
+var ByteArray = imports.byteArray;
+
 var ExtensionSystem = imports.ui.extensionSystem;
 var ExtensionUtils = imports.misc.extensionUtils;
 
@@ -1964,7 +1966,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
             let file = Gio.file_new_for_path(sfile);
             file.load_contents_async(null, (source, result) => {
                 let as_r = source.load_contents_finish(result)
-                this.temperature = Math.round(parseInt(as_r[1]) / 1000);
+                this.temperature = Math.round(parseInt(ByteArray.toString(as_r[1])) / 1000);
                 if (this.fahrenheit_unit) {
                     this.temperature = Math.round(this.temperature * 1.8 + 32);
                 }
@@ -2035,7 +2037,7 @@ const Fan = class SystemMonitor_Fan extends ElementBase {
             let file = Gio.file_new_for_path(sfile);
             file.load_contents_async(null, (source, result) => {
                 let as_r = source.load_contents_finish(result)
-                this.rpm = parseInt(as_r[1]);
+                this.rpm = parseInt(ByteArray.toString(as_r[1]));
             });
         } else if (this.display_error) {
             global.logError('error reading: ' + sfile);

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1485,7 +1485,7 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
         let num_cpus = GTop.glibtop_get_sysinfo().ncpu;
         let i = 0;
         let file = Gio.file_new_for_path(`/sys/devices/system/cpu/cpu${i}/cpufreq/scaling_cur_freq`);
-        file.load_contents_async(null, (source, result) => {
+        file.load_contents_async(null, function cb (source, result) {
             let as_r = source.load_contents_finish(result);
             total_frequency += parseInt(as_r[1]);
 
@@ -1493,7 +1493,7 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
                 this.freq = Math.round(total_frequency / num_cpus / 1000);
             } else {
                 file = Gio.file_new_for_path(`/sys/devices/system/cpu/cpu${i}/cpufreq/scaling_cur_freq`);
-                file.load_contents_async(null, this.cb.bind(this));
+                file.load_contents_async(null, cb.bind(this));
             }
         });
     }

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -169,8 +169,7 @@ function interesting_mountpoint(mount) {
 
 
 const smStyleManager = class SystemMonitor_smStyleManager {
-
-    constructor () {
+    constructor() {
         this._extension = '';
         this._iconsize = 1;
         this._diskunits = _('MiB/s');
@@ -211,53 +210,52 @@ const smStyleManager = class SystemMonitor_smStyleManager {
             this._text_scaling = 1;
         }
     }
-    get (style) {
+    get(style) {
         return style + this._extension;
     }
-    iconsize () {
+    iconsize() {
         return this._iconsize;
     }
-    diskunits () {
+    diskunits() {
         return this._diskunits;
     }
-    netunits_kbytes () {
+    netunits_kbytes() {
         return this._netunits_kbytes;
     }
-    netunits_mbytes () {
+    netunits_mbytes() {
         return this._netunits_mbytes;
     }
-    netunits_kbits () {
+    netunits_kbits() {
         return this._netunits_kbits;
     }
-    netunits_mbits () {
+    netunits_mbits() {
         return this._netunits_mbits;
     }
-    pie_width () {
+    pie_width() {
         return this._pie_width;
     }
-    pie_height () {
+    pie_height() {
         return this._pie_height;
     }
-    pie_fontsize () {
+    pie_fontsize() {
         return this._pie_fontsize * this._text_scaling;
     }
-    bar_width () {
+    bar_width() {
         return this._bar_width;
     }
-    bar_height () {
+    bar_height() {
         return this._bar_height;
     }
-    bar_fontsize () {
+    bar_fontsize() {
         return this._bar_fontsize * this._text_scaling;
     }
-    text_scaling () {
+    text_scaling() {
         return this._text_scaling;
     }
 }
 
 const smDialog = class SystemMonitor_smDialog extends ModalDialog.ModalDialog {
-
-    constructor () {
+    constructor() {
         super({styleClass: 'prompt-dialog'});
         let mainContentBox = new St.BoxLayout({style_class: 'prompt-dialog-main-layout',
             vertical: false});
@@ -295,12 +293,10 @@ const smDialog = class SystemMonitor_smDialog extends ModalDialog.ModalDialog {
             }
         ]);
     }
-
 }
 
 const Chart = class SystemMonitor_Chart {
-
-    constructor (width, height, parent) {
+    constructor(width, height, parent) {
         this.actor = new St.DrawingArea({style_class: Style.get('sm-chart'), reactive: false});
         this.parentC = parent;
         this.actor.set_width(this.width = width);
@@ -311,7 +307,7 @@ const Chart = class SystemMonitor_Chart {
             this.data[i] = [];
         }
     }
-    update () {
+    update() {
         let data_a = this.parentC.vals;
         if (data_a.length !== this.parentC.colors.length) {
             return;
@@ -329,7 +325,7 @@ const Chart = class SystemMonitor_Chart {
         }
         this.actor.queue_repaint();
     }
-    _draw () {
+    _draw() {
         if (!this.actor.visible) {
             return;
         }
@@ -359,7 +355,7 @@ const Chart = class SystemMonitor_Chart {
             cr.$dispose();
         }
     }
-    resize (schema, key) {
+    resize(schema, key) {
         let old_width = this.width;
         this.width = Schema.get_int(key);
         if (old_width === this.width) {
@@ -376,8 +372,7 @@ const Chart = class SystemMonitor_Chart {
 
 // Class to deal with volumes insertion / ejection
 const smMountsMonitor = class SystemMonitor_smMountsMonitor {
-
-    constructor () {
+    constructor() {
         this.files = [];
         this.num_mounts = -1;
         this.listeners = [];
@@ -386,14 +381,14 @@ const smMountsMonitor = class SystemMonitor_smMountsMonitor {
         this._volumeMonitor = Gio.VolumeMonitor.get();
         let sys_mounts = ['/home', '/tmp', '/boot', '/usr', '/usr/local'];
         this.base_mounts = ['/'];
-        sys_mounts.forEach( (sMount) => {
+        sys_mounts.forEach((sMount) => {
             if (this.is_sys_mount(sMount + '/')) {
                 this.base_mounts.push(sMount);
             }
         });
         this.connect();
     }
-    refresh () {
+    refresh() {
         // try check that number of volumes has changed
         // try {
         //     let num_mounts = this.manager.getMounts().length;
@@ -421,7 +416,7 @@ const smMountsMonitor = class SystemMonitor_smMountsMonitor {
             this.mounts.push(this.base_mounts[base]);
         }
         let mount_lines = this._volumeMonitor.get_mounts();
-        mount_lines.forEach( (mount) => {
+        mount_lines.forEach((mount) => {
             if ((!this.is_net_mount(mount) || ENABLE_NETWORK_DISK_USAGE) &&
                  !this.is_ro_mount(mount)) {
                 let mpath = mount.get_root().get_path() || mount.get_default_location().get_path();
@@ -436,22 +431,22 @@ const smMountsMonitor = class SystemMonitor_smMountsMonitor {
             this.listeners[i](this.mounts);
         }
     }
-    add_listener (cb) {
+    add_listener(cb) {
         this.listeners.push(cb);
     }
-    remove_listener (cb) {
+    remove_listener(cb) {
         this.listeners.pop(cb);
     }
-    get_mounts () {
+    get_mounts() {
         return this.mounts;
     }
-    is_sys_mount (mpath) {
+    is_sys_mount(mpath) {
         let file = Gio.file_new_for_path(mpath);
         let info = file.query_info(Gio.FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT,
             Gio.FileQueryInfoFlags.NONE, null);
         return info.get_attribute_boolean(Gio.FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT);
     }
-    is_ro_mount (mount) {
+    is_ro_mount(mount) {
         // FIXME: running this function after "login after waking from suspend"
         // can make login hang. Actual issue seems to occur when a former net
         // mount got broken (e.g. due to a VPN connection terminated or
@@ -464,7 +459,7 @@ const smMountsMonitor = class SystemMonitor_smMountsMonitor {
             return false;
         }
     }
-    is_net_mount (mount) {
+    is_net_mount(mount) {
         try {
             let file = mount.get_default_location();
             let info = file.query_filesystem_info(Gio.FILE_ATTRIBUTE_FILESYSTEM_TYPE, null);
@@ -475,7 +470,7 @@ const smMountsMonitor = class SystemMonitor_smMountsMonitor {
             return false;
         }
     }
-    connect () {
+    connect() {
         if (this.connected) {
             return;
         }
@@ -491,7 +486,7 @@ const smMountsMonitor = class SystemMonitor_smMountsMonitor {
         }
         this.refresh();
     }
-    disconnect () {
+    disconnect() {
         if (!this.connected) {
             return;
         }
@@ -499,14 +494,13 @@ const smMountsMonitor = class SystemMonitor_smMountsMonitor {
         this.manager.disconnect(this.mount_removed_id);
         this.connected = false;
     }
-    destroy () {
+    destroy() {
         this.disconnect();
     }
 }
 
 const Graph = class SystemMonitor_Graph {
-
-    constructor (width, height) {
+    constructor(width, height) {
         this.menu_item = '';
         this.actor = new St.DrawingArea({style_class: Style.get('sm-chart'), reactive: false});
         this.width = width;
@@ -520,19 +514,18 @@ const Graph = class SystemMonitor_Graph {
             this.colors[color] = color_from_string(this.colors[color]);
         }
     }
-    create_menu_item () {
+    create_menu_item() {
         this.menu_item = new PopupMenu.PopupBaseMenuItem({reactive: false});
         this.menu_item.actor.add(this.actor, {span: -1, expand: true});
         // tray.menu.addMenuItem(this.menu_item);
     }
-    show (visible) {
+    show(visible) {
         this.menu_item.actor.visible = visible;
     }
 }
 
 const Bar = class SystemMonitor_Bar extends Graph {
-
-    constructor (width, height) {
+    constructor(width, height) {
         super(width, height);
         this.mounts = MountsMonitor.get_mounts();
         MountsMonitor.add_listener(this.update_mounts.bind(this));
@@ -540,7 +533,7 @@ const Bar = class SystemMonitor_Bar extends Graph {
         this.fontsize = Style.bar_fontsize();
         this.actor.set_height(this.mounts.length * (3 * this.thickness));
     }
-    _draw () {
+    _draw() {
         if (!this.actor.visible) {
             return;
         }
@@ -576,21 +569,20 @@ const Bar = class SystemMonitor_Bar extends Graph {
             cr.$dispose();
         }
     }
-    update_mounts (mounts) {
+    update_mounts(mounts) {
         this.mounts = mounts;
         this.actor.queue_repaint();
     }
 }
 
 const Pie = class SystemMonitor_Pie extends Graph {
-
-    constructor (width, height) {
+    constructor(width, height) {
         super(width, height);
         this.mounts = MountsMonitor.get_mounts();
         MountsMonitor.add_listener(this.update_mounts.bind(this));
     }
 
-    _draw () {
+    _draw() {
         if (!this.actor.visible) {
             return;
         }
@@ -635,15 +627,14 @@ const Pie = class SystemMonitor_Pie extends Graph {
         }
     }
 
-    update_mounts (mounts) {
+    update_mounts(mounts) {
         this.mounts = mounts;
         this.actor.queue_repaint();
     }
 }
 
 const TipItem = class SystemMonitor_TipItem extends PopupMenu.PopupBaseMenuItem {
-
-    constructor () {
+    constructor() {
         super();
         // PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
         this.actor.remove_style_class_name('popup-menu-item');
@@ -652,8 +643,7 @@ const TipItem = class SystemMonitor_TipItem extends PopupMenu.PopupBaseMenuItem 
 }
 
 const TipMenu = class SystemMonitor_TipMenu extends PopupMenu.PopupMenuBase {
-
-    constructor (sourceActor) {
+    constructor(sourceActor) {
         // PopupMenu.PopupMenuBase.prototype._init.call(this, sourceActor, 'sm-tooltip-box');
         super(sourceActor, 'sm-tooltip-box');
         this.actor = new Clutter.Actor();
@@ -675,7 +665,7 @@ const TipMenu = class SystemMonitor_TipMenu extends PopupMenu.PopupMenuBase {
     // _boxAllocate (actor, box, flags) {
     //     this.box.allocate(box, flags);
     // }
-    _shift () {
+    _shift() {
         // Probably old but works
         let node = this.sourceActor.get_theme_node();
         let contentbox = node.get_content_box(this.sourceActor.get_allocation_box());
@@ -698,7 +688,7 @@ const TipMenu = class SystemMonitor_TipMenu extends PopupMenu.PopupMenuBase {
         }
         this.actor.set_position(tipx, tipy);
     }
-    open (animate) {
+    open(animate) {
         if (this.isOpen) {
             return;
         }
@@ -709,7 +699,7 @@ const TipMenu = class SystemMonitor_TipMenu extends PopupMenu.PopupMenuBase {
         this.actor.raise_top();
         this.emit('open-state-changed', true);
     }
-    close (animate) {
+    close(animate) {
         this.isOpen = false;
         this.actor.hide();
         this.emit('open-state-changed', false);
@@ -717,8 +707,7 @@ const TipMenu = class SystemMonitor_TipMenu extends PopupMenu.PopupMenuBase {
 }
 
 const TipBox = class SystemMonitor_TipBox {
-
-    constructor () {
+    constructor() {
         this.actor = new St.BoxLayout({reactive: true});
         this.actor._delegate = this;
         this.set_tip(new TipMenu(this.actor));
@@ -726,7 +715,7 @@ const TipBox = class SystemMonitor_TipBox {
         this.actor.connect('enter-event', this.on_enter.bind(this));
         this.actor.connect('leave-event', this.on_leave.bind(this));
     }
-    set_tip (tipmenu) {
+    set_tip(tipmenu) {
         if (this.tipmenu) {
             this.tipmenu.destroy();
         }
@@ -736,7 +725,7 @@ const TipBox = class SystemMonitor_TipBox {
             this.hide_tip();
         }
     }
-    show_tip () {
+    show_tip() {
         if (!this.tipmenu) {
             return;
         }
@@ -746,7 +735,7 @@ const TipBox = class SystemMonitor_TipBox {
             this.in_to = 0;
         }
     }
-    hide_tip () {
+    hide_tip() {
         if (!this.tipmenu) {
             return;
         }
@@ -760,7 +749,7 @@ const TipBox = class SystemMonitor_TipBox {
             this.in_to = 0;
         }
     }
-    on_enter () {
+    on_enter() {
         let show_tooltip = Schema.get_boolean('show-tooltip');
 
         if (!show_tooltip) {
@@ -776,7 +765,7 @@ const TipBox = class SystemMonitor_TipBox {
                 this.show_tip.bind(this));
         }
     }
-    on_leave () {
+    on_leave() {
         if (this.in_to) {
             Mainloop.source_remove(this.in_to);
             this.in_to = 0;
@@ -786,7 +775,7 @@ const TipBox = class SystemMonitor_TipBox {
                 this.hide_tip.bind(this));
         }
     }
-    destroy () {
+    destroy() {
         if (this.in_to) {
             Mainloop.source_remove(this.in_to);
             this.in_to = 0;
@@ -802,17 +791,16 @@ const TipBox = class SystemMonitor_TipBox {
 }
 
 const ElementBase = class SystemMonitor_ElementBase extends TipBox {
-
-    constructor (properties) {
+    constructor(properties) {
         super();
-    	this.elt = '';
+        this.elt = '';
         this.item_name = _('');
         this.color_name = [];
         this.text_items = [];
         this.menu_items = [];
         this.menu_visible = true;
 
-    	Object.assign(this, properties);
+        Object.assign(this, properties);
 
         //            TipBox.prototype._init.apply(this, arguments);
         this.vals = [];
@@ -825,24 +813,24 @@ const ElementBase = class SystemMonitor_ElementBase extends TipBox {
             let name = this.elt + '-' + this.color_name[color] + '-color';
             let clutterColor = color_from_string(Schema.get_string(name));
             Schema.connect('changed::' + name, (schema, key) => {
-                    this.clutterColor = color_from_string(Schema.get_string(key));
-                });
+                this.clutterColor = color_from_string(Schema.get_string(key));
+            });
             Schema.connect('changed::' + name, () => {
-                    this.chart.actor.queue_repaint();
-                });
+                this.chart.actor.queue_repaint();
+            });
             this.colors.push(clutterColor);
         }
 
         this.chart = new Chart(Schema.get_int(this.elt + '-graph-width'), IconSize, this);
         Schema.connect('changed::background', () => {
-                    this.chart.actor.queue_repaint();
-                });
+            this.chart.actor.queue_repaint();
+        });
 
         this.actor.visible = Schema.get_boolean(this.elt + '-display');
         Schema.connect(
             'changed::' + this.elt + '-display', (schema, key) => {
-                    this.actor.visible = Schema.get_boolean(key);
-                });
+                this.actor.visible = Schema.get_boolean(key);
+            });
 
         this.interval = l_limit(Schema.get_int(this.elt + '-refresh-time'));
         this.timeout = Mainloop.timeout_add(
@@ -851,25 +839,25 @@ const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         );
         Schema.connect(
             'changed::' + this.elt + '-refresh-time',
-                (schema, key) => {
-                    Mainloop.source_remove(this.timeout);
-                    this.timeout = null;
-                    this.interval = l_limit(Schema.get_int(key));
-                    this.timeout = Mainloop.timeout_add(
-                        this.interval, this.update.bind(this));
-                });
+            (schema, key) => {
+                Mainloop.source_remove(this.timeout);
+                this.timeout = null;
+                this.interval = l_limit(Schema.get_int(key));
+                this.timeout = Mainloop.timeout_add(
+                    this.interval, this.update.bind(this));
+            });
         Schema.connect('changed::' + this.elt + '-graph-width',
             this.chart.resize.bind(this.chart));
 
         if (this.elt === 'thermal') {
             Schema.connect('changed::thermal-threshold',
-                    () => {
-                        Mainloop.source_remove(this.timeout);
-                        this.timeout = null;
-                        this.reset_style();
-                        this.timeout = Mainloop.timeout_add(
-                            this.interval, this.update.bind(this));
-                    });
+                () => {
+                    Mainloop.source_remove(this.timeout);
+                    this.timeout = null;
+                    this.reset_style();
+                    this.timeout = Mainloop.timeout_add(
+                        this.interval, this.update.bind(this));
+                });
         }
 
         this.label = new St.Label({text: this.elt === 'memory' ? _('mem') : _(this.elt),
@@ -893,7 +881,7 @@ const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         Schema.connect('changed::' + this.elt + '-style', change_style.bind(this));
         this.menu_items = this.create_menu_items();
     }
-    tip_format (unit) {
+    tip_format(unit) {
         if (typeof (unit) === 'undefined') {
             unit = '%';
         }
@@ -921,7 +909,7 @@ const ElementBase = class SystemMonitor_ElementBase extends TipBox {
     //           this.tip_unit_labels[i].text = unit[i];
     //           }
     //           }
-    update () {
+    update() {
         if (!this.menu_visible && !this.actor.visible) {
             return false;
         }
@@ -936,10 +924,10 @@ const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         }
         return true;
     }
-    reset_style () {
+    reset_style() {
         this.text_items[0].set_style('color: rgba(255, 255, 255, 1)');
     }
-    threshold () {
+    threshold() {
         if (Schema.get_int('thermal-threshold')) {
             if (this.temp_over_threshold) {
                 this.text_items[0].set_style('color: rgba(255, 0, 0, 1)');
@@ -948,7 +936,7 @@ const ElementBase = class SystemMonitor_ElementBase extends TipBox {
             }
         }
     }
-    destroy () {
+    destroy() {
         TipBox.prototype.destroy.call(this);
         if (this.timeout) {
             Mainloop.source_remove(this.timeout);
@@ -958,14 +946,13 @@ const ElementBase = class SystemMonitor_ElementBase extends TipBox {
 }
 
 const Battery = class SystemMonitor_Battery extends ElementBase {
-
-    constructor () {
+    constructor() {
         super({
-    		elt: 'battery',
-    		item_name: _('Battery'),
-    		color_name: ['batt0'],
+            elt: 'battery',
+            item_name: _('Battery'),
+            color_name: ['batt0'],
             icon: '. GThemedIcon battery-good-symbolic battery-good'
-    	});
+        });
 
         this.max = 100;
         this.icon_hidden = false;
@@ -990,10 +977,10 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
         // Schema.connect('changed::' + this.elt + '-hidesystem', this.hide_system_icon.bind(this));
         Schema.connect('changed::' + this.elt + '-time', this.update_tips.bind(this));
     }
-    refresh () {
+    refresh() {
         // do nothing here?
     }
-    update_battery () {
+    update_battery() {
         // callback function for when battery stats updated.
         let battery_found = false;
         let isBattery = false;
@@ -1048,7 +1035,7 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
             });
         }
     }
-    update_battery_value (seconds, percentage, icon) {
+    update_battery_value(seconds, percentage, icon) {
         if (seconds > 60) {
             let time = Math.round(seconds / 60);
             let minutes = time % 60;
@@ -1068,7 +1055,7 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
             build_menu_info();
         }
     }
-    hide_system_icon (override) {
+    hide_system_icon(override) {
         let value = Schema.get_boolean(this.elt + '-hidesystem');
         if (!override) {
             value = false;
@@ -1101,7 +1088,7 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
             // Main.panel._updatePanel('right');
         }
     }
-    get_battery_unit () {
+    get_battery_unit() {
         let unitString;
         let value = Schema.get_boolean(this.elt + '-time');
 
@@ -1113,7 +1100,7 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
 
         return unitString;
     }
-    update_tips () {
+    update_tips() {
         let unitString = this.get_battery_unit();
 
         if (Schema.get_boolean(this.elt + '-display')) {
@@ -1125,7 +1112,7 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
 
         this.update();
     }
-    _apply () {
+    _apply() {
         let displayString;
         let value = Schema.get_boolean(this.elt + '-time');
         if (value) {
@@ -1143,7 +1130,7 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
         this.vals = [this.percentage];
         this.tip_vals[0] = Math.round(this.percentage);
     }
-    create_text_items () {
+    create_text_items() {
         return [
             new St.Icon({
                 gicon: Gio.icon_new_for_string(this.icon),
@@ -1158,7 +1145,7 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
                 y_align: Clutter.ActorAlign.CENTER})
         ];
     }
-    create_menu_items () {
+    create_menu_items() {
         return [
             new St.Label({
                 text: '',
@@ -1168,21 +1155,20 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
                 style_class: Style.get('sm-label')})
         ];
     }
-    destroy () {
+    destroy() {
         ElementBase.prototype.destroy.call(this);
         this._proxy.disconnect(this.powerSigID);
     }
 }
 
 const Cpu = class SystemMonitor_Cpu extends ElementBase {
-
-    constructor (cpuid) {
+    constructor(cpuid) {
         super({
             elt: 'cpu',
             item_name: _('CPU'),
             color_name: ['user', 'system', 'nice', 'iowait', 'other'],
             cpuid: -1 // cpuid is -1 when all cores are displayed in the same graph
-    	});
+        });
         this.max = 100;
 
         this.cpuid = cpuid;
@@ -1208,7 +1194,7 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
         this.tip_format();
         this.update();
     }
-    refresh () {
+    refresh() {
         GTop.glibtop_get_cpu(this.gtop);
         // display global cpu usage on 1 graph
         if (this.cpuid === -1) {
@@ -1288,7 +1274,7 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
         //         this.last_total = this.gtop.xcpu_total[this.cpuid];
         // }
     }
-    _apply () {
+    _apply() {
         let percent = 0;
         if (this.cpuid === -1) {
             percent = Math.round(((100 * this.total_cores) - this.usage[3]) /
@@ -1311,7 +1297,7 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
         }
     }
 
-    get_cores () {
+    get_cores() {
         // Getting xcpu_total makes gjs 1.29.18 segfault
         // let cores = 0;
         // GTop.glibtop_get_cpu(this.gtop);
@@ -1323,7 +1309,7 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
         // return cores;
         return 1;
     }
-    create_text_items () {
+    create_text_items() {
         return [
             new St.Label({
                 text: '',
@@ -1334,7 +1320,7 @@ const Cpu = class SystemMonitor_Cpu extends ElementBase {
                 y_align: Clutter.ActorAlign.CENTER})
         ];
     }
-    create_menu_items () {
+    create_menu_items() {
         return [
             new St.Label({
                 text: '',
@@ -1379,10 +1365,9 @@ function createCpus() {
 }
 
 const Disk = class SystemMonitor_Disk extends ElementBase {
-
-    constructor () {
+    constructor() {
         super({
-        	elt: 'disk',
+            elt: 'disk',
             item_name: _('Disk'),
             color_name: ['read', 'write']
         });
@@ -1394,10 +1379,10 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         this.tip_format(_('MiB/s'));
         this.update();
     }
-    update_mounts (mounts) {
+    update_mounts(mounts) {
         this.mounts = mounts;
     }
-    refresh () {
+    refresh() {
         let accum = [0, 0];
         let lines = Shell.get_file_contents_utf8_sync('/proc/diskstats').split('\n');
 
@@ -1421,7 +1406,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         }
         this.last_time = time;
     }
-    _apply () {
+    _apply() {
         this.vals = this.usage.slice();
         for (let i = 0; i < 2; i++) {
             if (this.usage[i] < 10) {
@@ -1434,7 +1419,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         this.menu_items[0].text = this.text_items[1].text = this.tip_vals[0].toLocaleString(Locale);
         this.menu_items[3].text = this.text_items[4].text = this.tip_vals[1].toLocaleString(Locale);
     }
-    create_text_items () {
+    create_text_items() {
         return [
             new St.Label({
                 text: _('R'),
@@ -1460,7 +1445,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
                 y_align: Clutter.ActorAlign.CENTER})
         ];
     }
-    create_menu_items () {
+    create_menu_items() {
         return [
             new St.Label({
                 text: '',
@@ -1485,8 +1470,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
 }
 
 const Freq = class SystemMonitor_Freq extends ElementBase {
-
-    constructor () {
+    constructor() {
         super({
             elt: 'freq',
             item_name: _('Freq'),
@@ -1496,7 +1480,7 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
         this.tip_format('MHz');
         this.update();
     }
-    refresh () {
+    refresh() {
         let total_frequency = 0;
         let num_cpus = GTop.glibtop_get_sysinfo().ncpu;
         let i = 0;
@@ -1509,11 +1493,11 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
                 this.freq = Math.round(total_frequency / num_cpus / 1000);
             } else {
                 file = Gio.file_new_for_path(`/sys/devices/system/cpu/cpu${i}/cpufreq/scaling_cur_freq`);
-                file.load_contents_async(null, cb.bind(this));
+                file.load_contents_async(null, this.cb.bind(this));
             }
         });
     }
-    _apply () {
+    _apply() {
         let value = this.freq.toString();
         this.text_items[0].text = value + ' ';
         this.vals[0] = value;
@@ -1525,14 +1509,14 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
         }
     }
     // pad a string with leading spaces
-    _pad (number, length) {
+    _pad(number, length) {
         var str = '' + number;
         while (str.length < length) {
             str = ' ' + str;
         }
         return str;
     }
-    create_text_items () {
+    create_text_items() {
         return [
             new St.Label({
                 text: '',
@@ -1543,7 +1527,7 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
                 y_align: Clutter.ActorAlign.CENTER})
         ];
     }
-    create_menu_items () {
+    create_menu_items() {
         return [
             new St.Label({
                 text: '',
@@ -1555,9 +1539,8 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
     }
 }
 
-const Mem = class SystemMonitor_Mem extends ElementBase{
-
-    constructor () {
+const Mem = class SystemMonitor_Mem extends ElementBase {
+    constructor() {
         super({
             elt: 'memory',
             item_name: _('Memory'),
@@ -1582,7 +1565,7 @@ const Mem = class SystemMonitor_Mem extends ElementBase{
         this.tip_format();
         this.update();
     }
-    refresh () {
+    refresh() {
         GTop.glibtop_get_mem(this.gtop);
         if (this.useGiB) {
             this.mem[0] = Math.round(this.gtop.user / this._unitConversion);
@@ -1600,7 +1583,7 @@ const Mem = class SystemMonitor_Mem extends ElementBase{
             this.total = Math.round(this.gtop.total / this._unitConversion);
         }
     }
-    _pad (number) {
+    _pad(number) {
         if (this.useGiB) {
             if (number < 1) {
                 // examples: 0.01, 0.10, 0.88
@@ -1612,7 +1595,7 @@ const Mem = class SystemMonitor_Mem extends ElementBase{
 
         return number;
     }
-    _apply () {
+    _apply() {
         if (this.total === 0) {
             this.vals = this.tip_vals = [0, 0, 0];
         } else {
@@ -1631,7 +1614,7 @@ const Mem = class SystemMonitor_Mem extends ElementBase{
                 '/' + this._pad(this.total).toLocaleString(Locale);
         }
     }
-    create_text_items () {
+    create_text_items() {
         return [
             new St.Label({
                 text: '',
@@ -1642,7 +1625,7 @@ const Mem = class SystemMonitor_Mem extends ElementBase{
                 y_align: Clutter.ActorAlign.CENTER})
         ];
     }
-    create_menu_items () {
+    create_menu_items() {
         let unit = _('MiB');
         if (this.useGiB) {
             unit = _('GiB');
@@ -1667,8 +1650,7 @@ const Mem = class SystemMonitor_Mem extends ElementBase{
 }
 
 const Net = class SystemMonitor_Net extends ElementBase {
-
-    constructor () {
+    constructor() {
         super({
             elt: 'net',
             item_name: _('Net'),
@@ -1709,10 +1691,10 @@ const Net = class SystemMonitor_Net extends ElementBase {
         }
         this.update();
     }
-    update_units () {
+    update_units() {
         this.speed_in_bits = Schema.get_boolean(this.elt + '-speed-in-bits');
     }
-    update_iface_list () {
+    update_iface_list() {
         try {
             this.ifs = [];
             let iface_list = this.client.get_devices();
@@ -1725,7 +1707,7 @@ const Net = class SystemMonitor_Net extends ElementBase {
             global.logError('Please install Network Manager Gobject Introspection Bindings');
         }
     }
-    refresh () {
+    refresh() {
         let accum = [0, 0, 0, 0, 0];
 
         for (let ifn in this.ifs) {
@@ -1750,7 +1732,7 @@ const Net = class SystemMonitor_Net extends ElementBase {
     }
 
     // pad a string with leading spaces
-    _pad (number, length) {
+    _pad(number, length) {
         var str = '' + number;
         while (str.length < length) {
             str = ' ' + str;
@@ -1758,7 +1740,7 @@ const Net = class SystemMonitor_Net extends ElementBase {
         return str;
     }
 
-    _apply () {
+    _apply() {
         this.tip_vals = this.usage;
         if (this.speed_in_bits) {
             this.tip_vals[0] = Math.round(this.tip_vals[0] * 8.192);
@@ -1806,7 +1788,7 @@ const Net = class SystemMonitor_Net extends ElementBase {
             this.menu_items[3].text = this.text_items[4].text = this._pad(this.tip_vals[2].toString(), 4);
         }
     }
-    create_text_items () {
+    create_text_items() {
         return [
             new St.Icon({
                 icon_size: 2 * IconSize / 3 * Style.iconsize(),
@@ -1832,7 +1814,7 @@ const Net = class SystemMonitor_Net extends ElementBase {
                 y_align: Clutter.ActorAlign.CENTER})
         ];
     }
-    create_menu_items () {
+    create_menu_items() {
         return [
             new St.Label({
                 text: '',
@@ -1857,8 +1839,7 @@ const Net = class SystemMonitor_Net extends ElementBase {
 }
 
 const Swap = class SystemMonitor_Swap extends ElementBase {
-
-    constructor () {
+    constructor() {
         super({
             elt: 'swap',
             item_name: _('Swap'),
@@ -1881,7 +1862,7 @@ const Swap = class SystemMonitor_Swap extends ElementBase {
         this.tip_format();
         this.update();
     }
-    refresh () {
+    refresh() {
         GTop.glibtop_get_swap(this.gtop);
         if (this.useGiB) {
             this.swap = Math.round(this.gtop.used / this._unitConversion);
@@ -1893,7 +1874,7 @@ const Swap = class SystemMonitor_Swap extends ElementBase {
             this.total = Math.round(this.gtop.total / this._unitConversion);
         }
     }
-    _pad (number) {
+    _pad(number) {
         if (this.useGiB) {
             if (number < 1) {
                 // examples: 0.01, 0.10, 0.88
@@ -1905,7 +1886,7 @@ const Swap = class SystemMonitor_Swap extends ElementBase {
 
         return number;
     }
-    _apply () {
+    _apply() {
         if (this.total === 0) {
             this.vals = this.tip_vals = [0];
         } else {
@@ -1923,7 +1904,7 @@ const Swap = class SystemMonitor_Swap extends ElementBase {
         }
     }
 
-    create_text_items () {
+    create_text_items() {
         return [
             new St.Label({
                 text: '',
@@ -1935,7 +1916,7 @@ const Swap = class SystemMonitor_Swap extends ElementBase {
                 y_align: Clutter.ActorAlign.CENTER})
         ];
     }
-    create_menu_items () {
+    create_menu_items() {
         let unit = 'MiB';
         if (this.useGiB) {
             unit = 'GiB';
@@ -1961,8 +1942,7 @@ const Swap = class SystemMonitor_Swap extends ElementBase {
 }
 
 const Thermal = class SystemMonitor_Thermal extends ElementBase {
-
-    constructor () {
+    constructor() {
         super({
             elt: 'thermal',
             item_name: _('Thermal'),
@@ -1978,7 +1958,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
         Schema.connect('changed::' + this.elt + '-sensor-file', this.refresh.bind(this));
         this.update();
     }
-    refresh () {
+    refresh() {
         let sfile = Schema.get_string(this.elt + '-sensor-file');
         if (GLib.file_test(sfile, 1 << 4)) {
             let file = Gio.file_new_for_path(sfile);
@@ -1996,7 +1976,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
 
         this.fahrenheit_unit = Schema.get_boolean(this.elt + '-fahrenheit-unit');
     }
-    _apply () {
+    _apply() {
         this.text_items[0].text = this.menu_items[0].text = this.temperature_text();
         // Making it looks better in chart.
         // this.vals = [this.temperature / 100];
@@ -2006,7 +1986,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
         this.menu_items[1].text = this.temperature_symbol();
         this.tip_unit_labels[0].text = _(this.temperature_symbol());
     }
-    create_text_items () {
+    create_text_items() {
         return [
             new St.Label({
                 text: '',
@@ -2018,7 +1998,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
                 y_align: Clutter.ActorAlign.CENTER})
         ];
     }
-    create_menu_items () {
+    create_menu_items() {
         return [
             new St.Label({
                 text: '',
@@ -2028,17 +2008,16 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
                 style_class: Style.get('sm-label')})
         ];
     }
-    temperature_text () {
+    temperature_text() {
         return this.temperature.toString();
     }
-    temperature_symbol () {
+    temperature_symbol() {
         return this.fahrenheit_unit ? '\u2109' : '\u2103';
     }
 }
 
 const Fan = class SystemMonitor_Fan extends ElementBase {
-
-    constructor () {
+    constructor() {
         super({
             elt: 'fan',
             item_name: _('Fan'),
@@ -2050,7 +2029,7 @@ const Fan = class SystemMonitor_Fan extends ElementBase {
         Schema.connect('changed::' + this.elt + '-sensor-file', this.refresh.bind(this));
         this.update();
     }
-    refresh () {
+    refresh() {
         let sfile = Schema.get_string(this.elt + '-sensor-file');
         if (GLib.file_test(sfile, 1 << 4)) {
             let file = Gio.file_new_for_path(sfile);
@@ -2063,13 +2042,13 @@ const Fan = class SystemMonitor_Fan extends ElementBase {
             this.display_error = false;
         }
     }
-    _apply () {
+    _apply() {
         this.text_items[0].text = this.rpm.toString();
         this.menu_items[0].text = this.rpm.toString();
         this.vals = [this.rpm / 10];
         this.tip_vals[0] = this.rpm;
     }
-    create_text_items () {
+    create_text_items() {
         return [
             new St.Label({
                 text: '',
@@ -2080,7 +2059,7 @@ const Fan = class SystemMonitor_Fan extends ElementBase {
                 y_align: Clutter.ActorAlign.CENTER})
         ];
     }
-    create_menu_items () {
+    create_menu_items() {
         return [
             new St.Label({
                 text: '',
@@ -2092,9 +2071,8 @@ const Fan = class SystemMonitor_Fan extends ElementBase {
     }
 }
 
-const Gpu = class SystemMonitor_Gpu extends ElementBase{
-
-    constructor () {
+const Gpu = class SystemMonitor_Gpu extends ElementBase {
+    constructor() {
         super({
             elt: 'gpu',
             item_name: _('GPU'),
@@ -2108,7 +2086,7 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase{
         this.tip_format();
         this.update();
     }
-    _unit (total) {
+    _unit(total) {
         this.total = total;
         let threshold = 4 * 1024; // In MiB
         this.useGiB = false;
@@ -2119,7 +2097,7 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase{
             this._unitConversion *= 1024 / this._decimals;
         }
     }
-    refresh () {
+    refresh() {
         // Run asynchronously, to avoid shell freeze
         try {
             let path = Me.dir.get_path();
@@ -2156,7 +2134,7 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase{
             // Deal with the error
         }
     }
-    _readTemperature () {
+    _readTemperature() {
         let usage = [];
         let out, size;
         if (this._process_stream) {
@@ -2188,13 +2166,13 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase{
 
         this._endProcess();
     }
-    _endProcess () {
+    _endProcess() {
         if (this._process_stream) {
             this._process_stream.close(null);
             this._process_stream = null;
         }
     }
-    _pad (number) {
+    _pad(number) {
         if (this.useGiB) {
             if (number < 1) {
                 // examples: 0.01, 0.10, 0.88
@@ -2206,7 +2184,7 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase{
 
         return number;
     }
-    _apply () {
+    _apply() {
         if (this.total === 0) {
             this.vals = [0];
             this.tip_vals = [0];
@@ -2224,7 +2202,7 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase{
                 '/' + this._pad(this.total).toLocaleString();
         }
     }
-    create_text_items () {
+    create_text_items() {
         return [
             new St.Label({
                 text: '',
@@ -2236,7 +2214,7 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase{
                 y_align: Clutter.ActorAlign.CENTER})
         ];
     }
-    create_menu_items () {
+    create_menu_items() {
         let unit = _('MiB');
         if (this.useGiB) {
             unit = _('GiB');
@@ -2262,8 +2240,7 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase{
 }
 
 const Icon = class SystemMonitor_Icon {
-
-    constructor () {
+    constructor() {
         this.actor = new St.Icon({icon_name: 'utilities-system-monitor-symbolic',
             style_class: 'system-status-icon'});
         this.actor.visible = Schema.get_boolean('icon-display');
@@ -2290,8 +2267,7 @@ function init() {
     IconSize = Math.round(Panel.PANEL_ICON_SIZE * 4 / 5);
 }
 
-function enable () {
-
+function enable() {
     log('[System monitor] applet enabling');
     Schema = Convenience.getSettings();
 
@@ -2342,10 +2318,10 @@ function enable () {
         Main.__sm.elts.push(new Disk());
         Main.__sm.elts.push(new Gpu());
         Main.__sm.elts.push(new Thermal());
-	    Main.__sm.elts.push(new Fan());
+        Main.__sm.elts.push(new Fan());
         Main.__sm.elts.push(new Battery());
 
-	    let tray = Main.__sm.tray;
+        let tray = Main.__sm.tray;
         let elts = Main.__sm.elts;
 
         if (Schema.get_boolean('move-clock')) {
@@ -2363,8 +2339,8 @@ function enable () {
         }
 
         Schema.connect('changed::background', (schema, key) => {
-                Background = color_from_string(Schema.get_string(key));
-            });
+            Background = color_from_string(Schema.get_string(key));
+        });
         if (!Compat.versionCompare(shell_Version, '3.5.5')) {
             StatusArea.systemMonitor = tray;
             panel.insert_child_at_index(tray.actor, 1);
@@ -2454,7 +2430,7 @@ function enable () {
     log('[System monitor] applet enabling done');
 }
 
-function disable () {
+function disable() {
     // restore clock
     if (Main.__sm.tray.clockMoved) {
         let dateMenu;

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1487,15 +1487,16 @@ const Freq = class SystemMonitor_Freq extends ElementBase {
         let num_cpus = GTop.glibtop_get_sysinfo().ncpu;
         let i = 0;
         let file = Gio.file_new_for_path(`/sys/devices/system/cpu/cpu${i}/cpufreq/scaling_cur_freq`);
+        var that = this;
         file.load_contents_async(null, function cb (source, result) {
             let as_r = source.load_contents_finish(result);
             total_frequency += parseInt(as_r[1]);
 
             if (++i >= num_cpus) {
-                this.freq = Math.round(total_frequency / num_cpus / 1000);
+                that.freq = Math.round(total_frequency / num_cpus / 1000);
             } else {
                 file = Gio.file_new_for_path(`/sys/devices/system/cpu/cpu${i}/cpufreq/scaling_cur_freq`);
-                file.load_contents_async(null, cb.bind(this));
+                file.load_contents_async(null, cb.bind(that));
             }
         });
     }

--- a/system-monitor@paradoxxx.zero.gmail.com/metadata.json
+++ b/system-monitor@paradoxxx.zero.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.32"],
+    "shell-version": ["3.26", "3.28", "3.30", "3.32"],
     "uuid": "system-monitor@paradoxxx.zero.gmail.com",
     "name": "system-monitor",
     "url": "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet",

--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -67,7 +67,7 @@ function check_sensors(sensor_type) {
 
 
 const ColorSelect = class SystemMonitor_ColorSelect {
-    constructor (name) {
+    constructor(name) {
         this.label = new Gtk.Label({label: name + _(':')});
         this.picker = new Gtk.ColorButton();
         this.actor = new Gtk.HBox({spacing: 5});
@@ -75,7 +75,7 @@ const ColorSelect = class SystemMonitor_ColorSelect {
         this.actor.add(this.picker);
         this.picker.set_use_alpha(true);
     }
-    set_value (value) {
+    set_value(value) {
         let clutterColor = Compat.color_from_string(value);
         let color = new Gdk.RGBA();
         let ctemp = [clutterColor.red, clutterColor.green, clutterColor.blue, clutterColor.alpha / 255];
@@ -85,7 +85,7 @@ const ColorSelect = class SystemMonitor_ColorSelect {
 }
 
 const IntSelect = class SystemMonitor_IntSelect {
-    constructor (name) {
+    constructor(name) {
         this.label = new Gtk.Label({label: name + _(':')});
         this.spin = new Gtk.SpinButton();
         this.actor = new Gtk.HBox();
@@ -93,17 +93,17 @@ const IntSelect = class SystemMonitor_IntSelect {
         this.actor.add(this.spin);
         this.spin.set_numeric(true);
     }
-    set_args (minv, maxv, incre, page) {
+    set_args(minv, maxv, incre, page) {
         this.spin.set_range(minv, maxv);
         this.spin.set_increments(incre, page);
     }
-    set_value (value) {
+    set_value(value) {
         this.spin.set_value(value);
     }
 }
 
 const Select = class SystemMonitor_Select {
-    constructor (name) {
+    constructor(name) {
         this.label = new Gtk.Label({label: name + _(':')});
         // this.label.set_justify(Gtk.Justification.RIGHT);
         this.selector = new Gtk.ComboBoxText();
@@ -111,10 +111,10 @@ const Select = class SystemMonitor_Select {
         this.actor.add(this.label);
         this.actor.add(this.selector);
     }
-    set_value (value) {
+    set_value(value) {
         this.selector.set_active(value);
     }
-    add (items) {
+    add(items) {
         items.forEach((item) => {
             this.selector.append_text(item);
         })
@@ -134,7 +134,7 @@ function set_string(combo, schema, name, _slist) {
 }
 
 const SettingFrame = class SystemMonitor {
-    constructor (name, schema) {
+    constructor(name, schema) {
         this.schema = schema;
         this.label = new Gtk.Label({label: name});
         this.frame = new Gtk.Frame({border_width: 10});
@@ -152,7 +152,7 @@ const SettingFrame = class SystemMonitor {
     }
 
     /** Enforces child ordering of first 2 boxes by label */
-    _reorder () {
+    _reorder() {
         /** @return {string} label of/inside component */
         const labelOf = el => {
             if (el.get_children) {
@@ -168,7 +168,7 @@ const SettingFrame = class SystemMonitor {
         });
     }
 
-    add (key) {
+    add(key) {
         const configParent = key.substring(0, key.indexOf('-'));
         const config = key.substring(configParent.length + 1);
 
@@ -283,8 +283,7 @@ const SettingFrame = class SystemMonitor {
 }
 
 const App = class SystemMonitor_App {
-
-    constructor () {
+    constructor() {
         let setting_items = ['cpu', 'memory', 'swap', 'net', 'disk', 'gpu', 'thermal', 'fan', 'freq', 'battery'];
         let keys = Schema.list_keys();
 

--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -3,7 +3,6 @@ const Gio = imports.gi.Gio;
 const Gdk = imports.gi.Gdk;
 const GLib = imports.gi.GLib;
 const Clutter = imports.gi.Clutter;
-const Lang = imports.lang;
 
 const Gettext = imports.gettext.domain('system-monitor');
 
@@ -67,66 +66,60 @@ function check_sensors(sensor_type) {
 }
 
 
-const ColorSelect = new Lang.Class({
-    Name: 'SystemMonitor.ColorSelect',
-
-    _init: function (name) {
+const ColorSelect = class SystemMonitor_ColorSelect {
+    constructor (name) {
         this.label = new Gtk.Label({label: name + _(':')});
         this.picker = new Gtk.ColorButton();
         this.actor = new Gtk.HBox({spacing: 5});
         this.actor.add(this.label);
         this.actor.add(this.picker);
         this.picker.set_use_alpha(true);
-    },
-    set_value: function (value) {
+    }
+    set_value (value) {
         let clutterColor = Compat.color_from_string(value);
         let color = new Gdk.RGBA();
         let ctemp = [clutterColor.red, clutterColor.green, clutterColor.blue, clutterColor.alpha / 255];
         color.parse('rgba(' + ctemp.join(',') + ')');
         this.picker.set_rgba(color);
     }
-});
+}
 
-const IntSelect = new Lang.Class({
-    Name: 'SystemMonitor.IntSelect',
-
-    _init: function (name) {
+const IntSelect = class SystemMonitor_IntSelect {
+    constructor (name) {
         this.label = new Gtk.Label({label: name + _(':')});
         this.spin = new Gtk.SpinButton();
         this.actor = new Gtk.HBox();
         this.actor.add(this.label);
         this.actor.add(this.spin);
         this.spin.set_numeric(true);
-    },
-    set_args: function (minv, maxv, incre, page) {
+    }
+    set_args (minv, maxv, incre, page) {
         this.spin.set_range(minv, maxv);
         this.spin.set_increments(incre, page);
-    },
-    set_value: function (value) {
+    }
+    set_value (value) {
         this.spin.set_value(value);
     }
-});
+}
 
-const Select = new Lang.Class({
-    Name: 'SystemMonitor.Select',
-
-    _init: function (name) {
+const Select = class SystemMonitor_Select {
+    constructor (name) {
         this.label = new Gtk.Label({label: name + _(':')});
         // this.label.set_justify(Gtk.Justification.RIGHT);
         this.selector = new Gtk.ComboBoxText();
         this.actor = new Gtk.HBox({spacing: 5});
         this.actor.add(this.label);
         this.actor.add(this.selector);
-    },
-    set_value: function (value) {
-        this.selector.set_active(value);
-    },
-    add: function (items) {
-        items.forEach(Lang.bind(this, function (item) {
-            this.selector.append_text(item);
-        }));
     }
-});
+    set_value (value) {
+        this.selector.set_active(value);
+    }
+    add (items) {
+        items.forEach((item) => {
+            this.selector.append_text(item);
+        })
+    }
+}
 
 function set_enum(combo, schema, name) {
     Schema.set_enum(name, combo.get_active());
@@ -140,10 +133,8 @@ function set_string(combo, schema, name, _slist) {
     Schema.set_string(name, _slist[combo.get_active()]);
 }
 
-const SettingFrame = new Lang.Class({
-    Name: 'SystemMonitor.SettingFrame',
-
-    _init: function (name, schema) {
+const SettingFrame = class SystemMonitor {
+    constructor (name, schema) {
         this.schema = schema;
         this.label = new Gtk.Label({label: name});
         this.frame = new Gtk.Frame({border_width: 10});
@@ -158,10 +149,10 @@ const SettingFrame = new Lang.Class({
         this.vbox.pack_start(this.hbox1, true, false, 0);
         this.vbox.pack_start(this.hbox2, true, false, 0);
         this.vbox.pack_start(this.hbox3, true, false, 0);
-    },
+    }
 
     /** Enforces child ordering of first 2 boxes by label */
-    _reorder: function () {
+    _reorder () {
         /** @return {string} label of/inside component */
         const labelOf = el => {
             if (el.get_children) {
@@ -175,9 +166,9 @@ const SettingFrame = new Lang.Class({
                 .sort((c1, c2) => labelOf(c1).localeCompare(labelOf(c2)))
                 .forEach((child, index) => box.reorder_child(child, index));
         });
-    },
+    }
 
-    add: function (key) {
+    add (key) {
         const configParent = key.substring(0, key.indexOf('-'));
         const config = key.substring(configParent.length + 1);
 
@@ -289,21 +280,20 @@ const SettingFrame = new Lang.Class({
         }
         this._reorder();
     }
-});
+}
 
-const App = new Lang.Class({
-    Name: 'SystemMonitor.App',
+const App = class SystemMonitor_App {
 
-    _init: function () {
+    constructor () {
         let setting_items = ['cpu', 'memory', 'swap', 'net', 'disk', 'gpu', 'thermal', 'fan', 'freq', 'battery'];
         let keys = Schema.list_keys();
 
         this.items = [];
         this.settings = [];
 
-        setting_items.forEach(Lang.bind(this, function (setting) {
+        setting_items.forEach((setting) => {
             this.settings[setting] = new SettingFrame(_(setting.capitalize()), Schema);
-        }));
+        });
 
         this.main_vbox = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL,
             spacing: 10,
@@ -315,7 +305,7 @@ const App = new Lang.Class({
         });
         this.main_vbox.pack_start(this.hbox1, false, false, 0);
 
-        keys.forEach(Lang.bind(this, function (key) {
+        keys.forEach((key) => {
             if (key === 'icon-display') {
                 let item = new Gtk.CheckButton({label: _('Display Icon')});
                 // item.set_active(Schema.get_boolean(key))
@@ -362,16 +352,16 @@ const App = new Lang.Class({
                     this.settings[sections[0]].add(key);
                 }
             }
-        }));
+        });
         this.notebook = new Gtk.Notebook()
-        setting_items.forEach(Lang.bind(this, function (setting) {
+        setting_items.forEach((setting) => {
             this.notebook.append_page(this.settings[setting].frame, this.settings[setting].label)
             this.main_vbox.pack_start(this.notebook, true, true, 0)
             this.main_vbox.show_all();
-        }));
+        });
         this.main_vbox.show_all();
     }
-});
+}
 
 function buildPrefsWidget() {
     let widget = new App();


### PR DESCRIPTION
Finally after two nights, it works with the new gnome-shell 3.32:
* using ES6 classes (fixes: #508)
* `Shell.GenericContainer` converted to `Clutter.Actor` (#486)
* probably not compatible with non-ES6 gnome-shell

Evidence:
![Screenshot from 2019-03-15 00-07-54](https://user-images.githubusercontent.com/1734126/54374081-52968100-46b9-11e9-9089-180e9a012b0f.png)
![Screenshot from 2019-03-15 00-08-06](https://user-images.githubusercontent.com/1734126/54374066-4b6f7300-46b9-11e9-9e4b-8d16129ba4e1.png)

