### PR TITLE
Fedora

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifeq ($(strip $(DESTDIR)),)
   INSTALLBASE = $(HOME)/.local/share/gnome-shell/extensions
   SUDO=
 else
-  INSTALLBASE = $(DESTDIR)usr/share/gnome-shell/extensions
+  INSTALLBASE = $(DESTDIR)/usr/share/gnome-shell/extensions
   SUDO=sudo
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,11 @@ ifeq ($(strip $(DESTDIR)),)
   SUDO=
 else
   INSTALLBASE = $(DESTDIR)/usr/share/gnome-shell/extensions
+ifeq ($(BUILD_FOR_RPM),1)
+  SUDO=
+else
   SUDO=sudo
+endif
 endif
 
 ifdef VERSION
@@ -96,13 +100,17 @@ install: remove build
 	$(call msg,$@,$(SUDO) $(INSTALLBASE)/$(INSTALLNAME))
 	$(Q) $(SUDO) mkdir -p $(INSTALLBASE)/$(INSTALLNAME)
 	$(Q) $(SUDO) cp $(VV) -r ./_build/* $(INSTALLBASE)/$(INSTALLNAME)/
+ifeq ($(strip $(BUILD_FOR_RPM)),)
 	$(Q) $(MAKE) -s reload
+endif
 	$(call msg,$@,OK)
 
 remove:
 	$(call msg,$@,$(SUDO) $(INSTALLBASE)/$(INSTALLNAME))
 	$(Q) $(SUDO) rm $(VV) -fr $(INSTALLBASE)/$(INSTALLNAME)
+ifeq ($(strip $(BUILD_FOR_RPM)),)
 	$(Q) $(MAKE) -s reload
+endif
 	$(call msg,$@,OK)
 
 reload:


### PR DESCRIPTION
Hello,

These two commits were necessary to build Fedora package (fc30). 

The first one fixes a typo in Makefile DESTDIR variable when used for admin users.

The second one introduces one new variable BUILD_FOR_RPM in Makefile to not use 'sudo' and 'gnome-shell-extension-tool' only for this case. This variable have to be set to '1' for both build and install target of the Makefile to build a RPM package.

Comment about this are welcome.

Cordially,


-- 
NVieville