### PR TITLE
Get rid of synchronous Disk read

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1381,27 +1381,33 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
     }
     refresh() {
         let accum = [0, 0];
-        let lines = Shell.get_file_contents_utf8_sync('/proc/diskstats').split('\n');
 
-        for (let i = 0; i < lines.length; i++) {
-            let line = lines[i];
-            let entry = line.trim().split(/[\s]+/);
-            if (typeof (entry[1]) === 'undefined') {
-                break;
-            }
-            accum[0] += parseInt(entry[5]);
-            accum[1] += parseInt(entry[9]);
-        }
+        let file = Gio.file_new_for_path('/proc/diskstats');
+        var that = this;
+        file.load_contents_async(null, function cb(source, result) {
+            let lines = source.load_contents_finish(result).split('\n');
 
-        let time = GLib.get_monotonic_time() / 1000;
-        let delta = (time - this.last_time) / 1000;
-        if (delta > 0) {
-            for (let i = 0; i < 2; i++) {
-                this.usage[i] = ((accum[i] - this.last[i]) / delta / 1024 / 8);
-                this.last[i] = accum[i];
+            for (let i = 0; i < lines.length; i++) {
+                let line = lines[i];
+                let entry = line.trim().split(/[\s]+/);
+                if (typeof (entry[1]) === 'undefined') {
+                    break;
+                }
+                accum[0] += parseInt(entry[5]);
+                accum[1] += parseInt(entry[9]);
             }
-        }
-        this.last_time = time;
+
+            let time = GLib.get_monotonic_time() / 1000;
+            let delta = (time - that.last_time) / 1000;
+            if (delta > 0) {
+                for (let i = 0; i < 2; i++) {
+                    that.usage[i] = ((accum[i] - that.last[i]) / delta / 1024 / 8);
+                    that.last[i] = accum[i];
+                }
+            }
+            that.last_time = time;
+
+        });
     }
     _apply() {
         this.vals = this.usage.slice();

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1383,9 +1383,9 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         let accum = [0, 0];
 
         let file = Gio.file_new_for_path('/proc/diskstats');
-        var that = this;
-        file.load_contents_async(null, function cb(source, result) {
-            let lines = source.load_contents_finish(result).split('\n');
+        file.load_contents_async(null, (source, result) => {
+            let as_r = source.load_contents_finish(result);
+            let lines = String(as_r[1]).split('\n');
 
             for (let i = 0; i < lines.length; i++) {
                 let line = lines[i];
@@ -1398,15 +1398,14 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
             }
 
             let time = GLib.get_monotonic_time() / 1000;
-            let delta = (time - that.last_time) / 1000;
+            let delta = (time - this.last_time) / 1000;
             if (delta > 0) {
                 for (let i = 0; i < 2; i++) {
-                    that.usage[i] = ((accum[i] - that.last[i]) / delta / 1024 / 8);
-                    that.last[i] = accum[i];
+                    this.usage[i] = ((accum[i] - this.last[i]) / delta / 1024 / 8);
+                    this.last[i] = accum[i];
                 }
             }
-            that.last_time = time;
-
+            this.last_time = time;
         });
     }
     _apply() {


### PR DESCRIPTION
I've been experiencing freezes while using this extension and after reading the issues #496 and #207 I understood that they might be related to the synchronous Disk reads that can block the entire GNOME-shell. In this PR Ι follow a similar approach as @return42 to make the disk reads asynchronous. I tested it on my PC and it seems to work fine.

Please note that I don't typically code in JavaScript and I've never developed a Gnome Extension, so you can safely assume I have no idea what I'm doing here. **Please review carefully.**