### PR TITLE
Update installation instructions for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Before installing this extension, ensure you have the necessary system packages 
 
 * On Ubuntu:
 
-      $ sudo apt-get install gir1.2-gtop-2.0 gir1.2-networkmanager-1.0  gir1.2-clutter-1.0
+      $ sudo apt install gir1.2-gtop-2.0 gir1.2-nm-1.0 gir1.2-clutter-1.0
       
 * On Debian:
 


### PR DESCRIPTION
Package `gir1.2-networkmanager-1.0` is not available.

![Screenshot from 2020-01-09 00-51-07](https://user-images.githubusercontent.com/9459891/72007366-b8bd4780-327b-11ea-89ff-99832dbeb6a0.png)
