### PR TITLE
Update references to gir1.2-nm-1.0 for Ubuntu

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/README
+++ b/system-monitor@paradoxxx.zero.gmail.com/README
@@ -1,4 +1,4 @@
 Dependencies:
 libgtop and gir bindings
-    on Ubuntu: gir1.2-gtop-2.0, gir1.2-networkmanager-1.0
+    on Ubuntu: gir1.2-gtop-2.0, gir1.2-nm-1.0
     on Fedora: libgtop2-devel, NetworkManager-glib-devel

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -77,7 +77,7 @@ const _ = Gettext.gettext;
 const MESSAGE = _('Dependencies Missing\n\
 Please install: \n\
 libgtop, Network Manager and gir bindings \n\
-\t    on Ubuntu: gir1.2-gtop-2.0, gir1.2-networkmanager-1.0 \n\
+\t    on Ubuntu: gir1.2-gtop-2.0, gir1.2-nm-1.0 \n\
 \t    on Fedora: libgtop2-devel, NetworkManager-glib-devel \n\
 \t    on Arch: libgtop, networkmanager\n\
 \t    on openSUSE: typelib-1_0-GTop-2_0, typelib-1_0-NetworkManager-1_0\n');


### PR DESCRIPTION
There are a couple more places when references to `gir1.2-networkmanager-1.0` needed updating to `gir-1.2-nm-1.0` for Ubuntu 19.10 and 20.04; this pull request provides them.