### PR TITLE
Make it work with gnome-shell 3.36

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -35,7 +35,8 @@ var Lang = imports.lang;
 var Gio = imports.gi.Gio;
 var Shell = imports.gi.Shell;
 var St = imports.gi.St;
-var Power = imports.ui.status.power;
+const UPower = imports.gi.UPowerGlib;
+
 // const System = imports.system;
 var ModalDialog = imports.ui.modalDialog;
 
@@ -1037,7 +1038,7 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
         let isBattery = false;
         if (typeof (this._proxy.GetDevicesRemote) === 'undefined') {
             let device_type = this._proxy.Type;
-            isBattery = (device_type === Power.UPower.DeviceKind.BATTERY);
+            isBattery = (device_type === UPower.DeviceKind.BATTERY);
             if (isBattery) {
                 battery_found = true;
                 let icon = this._proxy.IconName;
@@ -1064,7 +1065,7 @@ const Battery = class SystemMonitor_Battery extends ElementBase {
                 for (let i = 0; i < result.length; i++) {
                     let [device_id, device_type, icon, percentage, state, seconds] = result[i];
 
-                    isBattery = (device_type === Power.UPower.DeviceKind.BATTERY);
+                    isBattery = (device_type === UPower.DeviceKind.BATTERY);
                     if (isBattery) {
                         battery_found = true;
                         this.update_battery_value(seconds, percentage, icon);

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -153,7 +153,7 @@ function build_menu_info() {
                 style_class: Style.get('sm-title'),
                 x_align: Clutter.ActorAlign.START,
                 y_align: Clutter.ActorAlign.CENTER
-	    }), 0, row_index, 1, 1);
+            }), 0, row_index, 1, 1);
 
         // Add item data to table
         let col_index = 1;
@@ -651,7 +651,7 @@ const Pie = class SystemMonitor_Pie extends Graph {
 
 const TipItem = GObject.registerClass(
     {
-        GTypeName:'TipItem'
+        GTypeName: 'TipItem'
     },
     class TipItem extends PopupMenu.PopupBaseMenuItem {
         _init() {
@@ -2387,9 +2387,9 @@ function enable() {
         let _appSys = Shell.AppSystem.get_default();
         let _gsmApp = _appSys.lookup_app('gnome-system-monitor.desktop');
         let _gsmPrefs = _appSys.lookup_app('gnome-shell-extension-prefs.desktop');
-        if (_gsmPrefs == null) {
+        if (_gsmPrefs === null) {
             _gsmPrefs = _appSys.lookup_app('org.gnome.Extensions.desktop');
-	}
+        }
         let item;
         item = new PopupMenu.PopupMenuItem(_('System Monitor...'));
         item.connect('activate', () => {

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -381,6 +381,9 @@ const Chart = class SystemMonitor_Chart {
         if (old_width === this.width) {
             return;
         }
+        if (Style.get('') === '-compact') {
+            this.width = Math.round(this.width / 1.5);
+        }
         this.actor.set_width(this.width);
         if (this.width < this.data[0].length) {
             for (let i = 0; i < this.parentC.colors.length; i++) {
@@ -1986,7 +1989,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
             let file = Gio.file_new_for_path(sfile);
             file.load_contents_async(null, (source, result) => {
                 let as_r = source.load_contents_finish(result)
-                this.temperature = Math.round(parseInt(as_r[1]) / 1000);
+                this.temperature = Math.round(parseInt(ByteArray.toString(as_r[1])) / 1000);
                 if (this.fahrenheit_unit) {
                     this.temperature = Math.round(this.temperature * 1.8 + 32);
                 }
@@ -2057,7 +2060,7 @@ const Fan = class SystemMonitor_Fan extends ElementBase {
             let file = Gio.file_new_for_path(sfile);
             file.load_contents_async(null, (source, result) => {
                 let as_r = source.load_contents_finish(result)
-                this.rpm = parseInt(as_r[1]);
+                this.rpm = parseInt(ByteArray.toString(as_r[1]));
             });
         } else if (this.display_error) {
             global.logError('error reading: ' + sfile);
@@ -2336,7 +2339,7 @@ function enable() {
         // The spacing adds a distance between the graphs/text on the top bar
         let spacing = Schema.get_boolean('compact-display') ? '1' : '4';
         let box = new St.BoxLayout({style: 'spacing: ' + spacing + 'px;'});
-        tray.actor.add_actor(box);
+        tray.add_actor(box);
         box.add_actor(Main.__sm.icon.actor);
         // Add items to panel box
         for (let elt in elts) {

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2387,6 +2387,9 @@ function enable() {
         let _appSys = Shell.AppSystem.get_default();
         let _gsmApp = _appSys.lookup_app('gnome-system-monitor.desktop');
         let _gsmPrefs = _appSys.lookup_app('gnome-shell-extension-prefs.desktop');
+        if (_gsmPrefs == null) {
+            _gsmPrefs = _appSys.lookup_app('org.gnome.Extensions.desktop');
+	}
         let item;
         item = new PopupMenu.PopupMenuItem(_('System Monitor...'));
         item.connect('activate', () => {

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -166,7 +166,11 @@ function build_menu_info() {
 
         row_index++;
     }
-    tray_menu._getMenuItems()[0].actor.get_last_child().add(menu_info_box_table, {expand: true});
+    if (shell_Version < '3.36') {
+        tray_menu._getMenuItems()[0].actor.get_last_child().add(menu_info_box_table, {expand: true});
+    } else {
+        tray_menu._getMenuItems()[0].actor.get_last_child().add_child(menu_info_box_table);
+    }
 }
 
 function change_menu() {
@@ -539,7 +543,11 @@ const Graph = class SystemMonitor_Graph {
     }
     create_menu_item() {
         this.menu_item = new PopupMenu.PopupBaseMenuItem({reactive: false});
-        this.menu_item.actor.add(this.actor, {span: -1, expand: true});
+        if (shell_Version < '3.36') {
+            this.menu_item.actor.add(this.actor, {span: -1, expand: true});
+        } else {
+            this.menu_item.actor.add_child(this.actor);
+        }
         // tray.menu.addMenuItem(this.menu_item);
     }
     show(visible) {
@@ -661,8 +669,8 @@ if (shell_Version < '3.36') {
             // PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
             this.actor.remove_style_class_name('popup-menu-item');
             this.actor.add_style_class_name('sm-tooltip-item');
-       }
-   }
+        }
+    }
 } else {
     var TipItem = GObject.registerClass(
         {
@@ -963,7 +971,7 @@ const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         for (let i = 0; i < this.tip_vals.length; i++) {
             if (this.tip_labels[i]) {
                 this.tip_labels[i].text = this.tip_vals[i].toString();
-	    }
+            }
         }
         return true;
     }
@@ -2464,8 +2472,11 @@ function disable() {
     for (let eltName in Main.__sm.elts) {
         Main.__sm.elts[eltName].destroy();
     }
-
-    Main.__sm.tray.actor.destroy();
+    if (shell_Version < '3.36') {
+        Main.__sm.tray.actor.destroy();
+    } else {
+        Main.__sm.tray.destroy();
+    }
     Main.__sm = null;
 
     log('[System monitor] applet disable');

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -652,20 +652,32 @@ const Pie = class SystemMonitor_Pie extends Graph {
     }
 }
 
-const TipItem = GObject.registerClass(
-    {
-        GTypeName: 'TipItem'
-    },
-    class TipItem extends PopupMenu.PopupBaseMenuItem {
-        _init() {
-            super._init();
+var TipItem = null;
+
+if (shell_Version < '3.36') {
+    var TipItem = class SystemMonitor_TipItem extends PopupMenu.PopupBaseMenuItem {
+        constructor() {
+            super();
             // PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
             this.actor.remove_style_class_name('popup-menu-item');
             this.actor.add_style_class_name('sm-tooltip-item');
+       }
+   }
+} else {
+    var TipItem = GObject.registerClass(
+        {
+            GTypeName: 'TipItem'
+        },
+        class TipItem extends PopupMenu.PopupBaseMenuItem {
+            _init() {
+                super._init();
+                // PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
+                this.actor.remove_style_class_name('popup-menu-item');
+                this.actor.add_style_class_name('sm-tooltip-item');
+            }
         }
-    }
-);
-
+    );
+}
 const TipMenu = class SystemMonitor_TipMenu extends PopupMenu.PopupMenuBase {
     constructor(sourceActor) {
         // PopupMenu.PopupMenuBase.prototype._init.call(this, sourceActor, 'sm-tooltip-box');
@@ -949,7 +961,9 @@ const ElementBase = class SystemMonitor_ElementBase extends TipBox {
         }
         this.chart.update();
         for (let i = 0; i < this.tip_vals.length; i++) {
-            this.tip_labels[i].text = this.tip_vals[i].toString();
+            if (this.tip_labels[i]) {
+                this.tip_labels[i].text = this.tip_vals[i].toString();
+	    }
         }
         return true;
     }
@@ -2339,7 +2353,11 @@ function enable() {
         // The spacing adds a distance between the graphs/text on the top bar
         let spacing = Schema.get_boolean('compact-display') ? '1' : '4';
         let box = new St.BoxLayout({style: 'spacing: ' + spacing + 'px;'});
-        tray.add_actor(box);
+        if (shell_Version < '3.36') {
+            tray.actor.add_actor(box);
+        } else {
+            tray.add_actor(box);
+        }
         box.add_actor(Main.__sm.icon.actor);
         // Add items to panel box
         for (let elt in elts) {

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -92,8 +92,9 @@ let shell_Version = Config.PACKAGE_VERSION;
 
 Clutter.Actor.prototype.raise_top = function raise_top() {
     const parent = this.get_parent();
-    if (!parent)
+    if (!parent) {
         return;
+    }
     parent.set_child_above_sibling(this, null);
 }
 Clutter.Actor.prototype.reparent = function reparent(newParent) {
@@ -134,7 +135,7 @@ function build_menu_info() {
 
     let menu_info_box_table = new St.Widget({
         style: 'padding: 10px 0px 10px 0px; spacing-rows: 10px; spacing-columns: 15px;',
-        layout_manager: new Clutter.GridLayout({ orientation: Clutter.Orientation.VERTICAL })
+        layout_manager: new Clutter.GridLayout({orientation: Clutter.Orientation.VERTICAL})
     });
     let menu_info_box_table_layout = menu_info_box_table.layout_manager;
 
@@ -150,7 +151,7 @@ function build_menu_info() {
             new St.Label({
                 text: elts[elt].item_name,
                 style_class: Style.get('sm-title'),
-		x_align: Clutter.ActorAlign.START,
+                x_align: Clutter.ActorAlign.START,
                 y_align: Clutter.ActorAlign.CENTER
 	    }), 0, row_index, 1, 1);
 
@@ -648,15 +649,19 @@ const Pie = class SystemMonitor_Pie extends Graph {
     }
 }
 
-const TipItem = GObject.registerClass({GTypeName:'TipItem'},
+const TipItem = GObject.registerClass(
+    {
+        GTypeName:'TipItem'
+    },
     class TipItem extends PopupMenu.PopupBaseMenuItem {
-    _init() {
-        super._init();
-        // PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
-        this.actor.remove_style_class_name('popup-menu-item');
-        this.actor.add_style_class_name('sm-tooltip-item');
+        _init() {
+            super._init();
+            // PopupMenu.PopupBaseMenuItem.prototype._init.call(this);
+            this.actor.remove_style_class_name('popup-menu-item');
+            this.actor.add_style_class_name('sm-tooltip-item');
+        }
     }
-});
+);
 
 const TipMenu = class SystemMonitor_TipMenu extends PopupMenu.PopupMenuBase {
     constructor(sourceActor) {

--- a/system-monitor@paradoxxx.zero.gmail.com/metadata.json
+++ b/system-monitor@paradoxxx.zero.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.26", "3.28", "3.30", "3.32", "3.34"],
+    "shell-version": ["3.26", "3.28", "3.30", "3.32", "3.34", "3.36"],
     "uuid": "system-monitor@paradoxxx.zero.gmail.com",
     "name": "system-monitor",
     "url": "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet",


### PR DESCRIPTION
Well actually it's for GNOME Shell 3.35.91 still, but hopefully no more changes required for 3.36.

References for where I got hints for the fixes:
* `TipItem` error (Tried to construct an object without a GType): http://gjs.guide/guides/gjs/transition.html#extending-gobject-classes
* removal of `raise_top`: https://github.com/paperwm/PaperWM/issues/212
* Depreciated `TableLayout`: https://mail.gnome.org/archives/commits-list/2014-August/msg01899.html