### PR TITLE
Fix: use latest way to call preferences

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2434,13 +2434,17 @@ function enable() {
 
         item = new PopupMenu.PopupMenuItem(_('Preferences...'));
         item.connect('activate', () => {
-            if (_gsmPrefs.get_state() === _gsmPrefs.SHELL_APP_STATE_RUNNING) {
-                _gsmPrefs.activate();
+            if (typeof ExtensionUtils.openPrefs === 'function') {
+                ExtensionUtils.openPrefs();
             } else {
-                let info = _gsmPrefs.get_app_info();
-                let timestamp = global.display.get_current_time_roundtrip();
-                info.launch_uris([metadata.uuid], global.create_app_launch_context(timestamp, -1));
-            }
+                if (_gsmPrefs.get_state() === _gsmPrefs.SHELL_APP_STATE_RUNNING) {
+                    _gsmPrefs.activate();
+                } else {
+                    let info = _gsmPrefs.get_app_info();
+                    let timestamp = global.display.get_current_time_roundtrip();
+                    info.launch_uris([metadata.uuid], global.create_app_launch_context(timestamp, -1));
+                }
+	    }
         });
         tray.menu.addMenuItem(item);
         Main.panel.menuManager.addMenu(tray.menu);


### PR DESCRIPTION
Fixes: https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/564#issuecomment-612870009 

This is how I discovered the fix:
```bash
/usr/bin/gnome-shell-extension-prefs system-monitor
WARNING: Passing an extension UUID as a command-line argument to
gnome-shell-extension-prefs is deprecated.

In GNOME Shell extensions, use ExtensionUtils.openPrefs()
(sample code:
https://github.com/Tudmotu/gnome-shell-extension-clipboard-indicator/pull/203)

In other modules, call the OpenExtensionPrefs D-Bus method instead.

Error: GDBus.Error:org.gnome.gjs.JSError.Error: Expected type filename for Argument 'path' but got type 'undefined'
```