### PR TITLE
Sensor scanning improvements

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -60,7 +60,7 @@ function check_sensors(sensor_type) {
                     return String(parse_bytearray(result[1])).split('\n')[0];
                 }
             } catch (e) {
-                global.log('[System monitor] error loading label from file ' + file.get_path() + ': ' + e);
+                log('[System monitor] error loading label from file ' + file.get_path() + ': ' + e);
             }
         }
         return null;
@@ -70,7 +70,7 @@ function check_sensors(sensor_type) {
         const chip_children = chip_dir.enumerate_children(
             'standard::name,standard::type', Gio.FileQueryInfoFlags.NONE, null);
         if (!chip_children) {
-            global.log('[System monitor] error enumerating children of chip ' + chip_dir.get_path());
+            log('[System monitor] error enumerating children of chip ' + chip_dir.get_path());
             return false;
         }
 
@@ -99,7 +99,7 @@ function check_sensors(sensor_type) {
     const hwmon_children = hwmon_dir.enumerate_children(
         'standard::name,standard::type', Gio.FileQueryInfoFlags.NONE, null);
     if (!hwmon_children) {
-        global.log('[System monitor] error enumerating hwmon children');
+        log('[System monitor] error enumerating hwmon children');
         return [[], []];
     }
 

--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -55,9 +55,9 @@ function check_sensors(sensor_type) {
         if (file.query_exists(null)) {
             // load_contents (and even cat) fails with "Invalid argument" for some label files
             try {
-                const result = file.load_contents(null);
-                if (result[0]) {
-                    return String(parse_bytearray(result[1])).split('\n')[0];
+                let [success, contents] = file.load_contents(null);
+                if (success) {
+                    return String(parse_bytearray(contents)).split('\n')[0];
                 }
             } catch (e) {
                 log('[System monitor] error loading label from file ' + file.get_path() + ': ' + e);

--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -45,30 +45,82 @@ function parse_bytearray(bytearray) {
 }
 
 function check_sensors(sensor_type) {
-    let inputs = [sensor_type + '1_input', sensor_type + '2_input', sensor_type + '3_input'];
-    let sensor_path = '/sys/class/hwmon/';
-    let sensor_list = [];
-    let string_list = [];
-    let test;
-    for (let j = 0; j < 6; j++) {
-        for (let k = 0; k < inputs.length; k++) {
-            test = sensor_path + 'hwmon' + j + '/' + inputs[k];
-            if (!GLib.file_test(test, GLib.FileTest.EXISTS)) {
-                test = sensor_path + 'hwmon' + j + '/device/' + inputs[k];
-                if (!GLib.file_test(test, GLib.FileTest.EXISTS)) {
-                    continue;
+    const hwmon_path = '/sys/class/hwmon/';
+    const hwmon_dir = Gio.file_new_for_path(hwmon_path);
+
+    const sensor_files = [];
+    const sensor_labels = [];
+
+    function get_label_from(file) {
+        if (file.query_exists(null)) {
+            // load_contents (and even cat) fails with "Invalid argument" for some label files
+            try {
+                const result = file.load_contents(null);
+                if (result[0]) {
+                    return String(parse_bytearray(result[1])).split('\n')[0];
                 }
+            } catch (e) {
+                global.log('[System monitor] error loading label from file ' + file.get_path() + ': ' + e);
             }
-            let sensor = test.substr(0, test.lastIndexOf('/'));
-            let result = GLib.file_get_contents(sensor + '/name');
-            if(result){
-                let label = String(parse_bytearray(result[1])).split('\n')[0];
-                string_list.push(label + ' - ' + inputs[k].split('_')[0].capitalize());
-                sensor_list.push(test);
+        }
+        return null;
+    }
+
+    function add_sensors_from(chip_dir, chip_label) {
+        const chip_children = chip_dir.enumerate_children(
+            'standard::name,standard::type', Gio.FileQueryInfoFlags.NONE, null);
+        if (!chip_children) {
+            global.log('[System monitor] error enumerating children of chip ' + chip_dir.get_path());
+            return false;
+        }
+
+        const input_entry_regex = new RegExp('^' + sensor_type + '(\\d+)_input$');
+        let info;
+        let added = false;
+        while ((info = chip_children.next_file(null))) {
+            if (info.get_file_type() !== Gio.FileType.REGULAR) {
+                continue;
+            }
+            const matches = info.get_name().match(input_entry_regex);
+            if (!matches) {
+                continue;
+            }
+            const input_ordinal = matches[1];
+            const input = chip_children.get_child(info);
+            const input_label = get_label_from(chip_dir.get_child(sensor_type + input_ordinal + '_label'));
+
+            sensor_files.push(input.get_path());
+            sensor_labels.push(chip_label + ' - ' + (input_label || input_ordinal));
+            added = true;
+        }
+        return added;
+    }
+
+    const hwmon_children = hwmon_dir.enumerate_children(
+        'standard::name,standard::type', Gio.FileQueryInfoFlags.NONE, null);
+    if (!hwmon_children) {
+        global.log('[System monitor] error enumerating hwmon children');
+        return [[], []];
+    }
+
+    let info;
+    while ((info = hwmon_children.next_file(null))) {
+        if (info.get_file_type() !== Gio.FileType.DIRECTORY || !info.get_name().match(/^hwmon\d+$/)) {
+            continue;
+        }
+        const chip = hwmon_children.get_child(info);
+        const chip_label = get_label_from(chip.get_child('name')) || chip.get_basename();
+
+        if (!add_sensors_from(chip, chip_label)) {
+            // This is here to provide compatibility with previous code, but I can't find any
+            // information about sensors being stored in chip/device directory. Can we delete it?
+            const chip_device = chip.get_child('device');
+            if (chip_device.query_exists(null)) {
+                add_sensors_from(chip_device, chip_label);
             }
         }
     }
-    return [sensor_list, string_list];
+    return [sensor_files, sensor_labels];
 }
 
 


### PR DESCRIPTION
Similarly as described in the linked issues, on my machine there are 9 chips:

```bash
andrzej:/sys/class/hwmon$ ls
hwmon0  hwmon1  hwmon2  hwmon3  hwmon4  hwmon5  hwmon6  hwmon7  hwmon8
```

Moreover, my machine is a hexa-core and so, chip `hwmon6` provides access to 7 temperature sensors (1 for the whole package + 6 for each core):

```bash
andrzej:/sys/class/hwmon/hwmon6$ ls temp*_input
temp1_input  temp2_input  temp3_input  temp4_input  temp5_input  temp6_input  temp7_input
```

Sensors are correctly reported by `sensors` utility:

```bash
andrzej:~$ sensors
iwlwifi_1-virtual-0
Adapter: Virtual device
temp1:        +41.0°C  

coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +47.0°C  (high = +100.0°C, crit = +100.0°C)
Core 0:        +47.0°C  (high = +100.0°C, crit = +100.0°C)
Core 1:        +47.0°C  (high = +100.0°C, crit = +100.0°C)
Core 2:        +47.0°C  (high = +100.0°C, crit = +100.0°C)
Core 3:        +46.0°C  (high = +100.0°C, crit = +100.0°C)
Core 4:        +47.0°C  (high = +100.0°C, crit = +100.0°C)
Core 5:        +47.0°C  (high = +100.0°C, crit = +100.0°C)

nvme-pci-3d00
Adapter: PCI adapter
Composite:    +31.9°C  (low  = -20.1°C, high = +77.8°C)
                       (crit = +81.8°C)
Sensor 1:     +31.9°C  (low  = -273.1°C, high = +65261.8°C)

BAT0-acpi-0
Adapter: ACPI interface
in0:         +13.04 V  
curr1:        +0.63 A  

pch_cannonlake-virtual-0
Adapter: Virtual device
Platform Controller Hub:  +47.0°C  

dell_smm-virtual-0
Adapter: Virtual device
CPU Fan:     2504 RPM
GPU Fan:     2488 RPM

acpitz-acpi-0
Adapter: ACPI interface
temp1:        +25.0°C  (crit = +107.0°C)
```

But existing implementation only examines first 6 of them, namely `hwmon[0-5]`; chips `hwmon[6-8]` are not examined. Also, the implementation considers only first 3 sensors for each chip, e.g. `temp[1-3]_input`, so even if all chips were scanned, it still wouldn't find temperature sensor for cores 2-5 in chip `hwmon6`. Indeed, this can be seen in the following screenshot:

![image](https://user-images.githubusercontent.com/41550889/79738720-6c16ed00-82fd-11ea-9f07-aac96e8b4b18.png)

This PR is my stab at making sensor scanning more robust. It examines all chips in `hwmon` and for each it considers all fan/temperature sensors. As a bonus it also looks at their labels and reports them in preferences. I followed [description of hwmon sysfs at kernel.org](https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface) during implementation. Despite not finding anything about sensors available in chip/device directories (e.g. under `/sys/class/hwmon/hwmon6/device`) I've retained scanning of chip/device directories to make the implementation backwards-compatible. With these changes, sensors are correctly discovered and reported in preferences:

![image](https://user-images.githubusercontent.com/41550889/79739821-03c90b00-82ff-11ea-9484-1d5d241cffaa.png)

I will appreciate any requests for changes, remarks or pointers.
I believe this PR fixes #565, fixes #560.