### PR TITLE
sanitize usage vals parsed from gpu_usage.sh script

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2174,8 +2174,8 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase {
         }
     }
     _sanitizeUsageValue(val){
-        val = parseInt( val );
-        if( isNaN(val) ) val = 0;
+        val = parseInt(val);
+        if(isNaN(val)){ val = 0 };
         return val;
     }
     _readTemperature(procOutput) {

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2173,11 +2173,16 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase {
             global.logError('gpu_usage.sh invocation failed');
         }
     }
+    _sanitizeUsageValue(val){
+        val = parseInt( val );
+        if( isNaN(val) ) val = 0;
+        return val;
+    }
     _readTemperature(procOutput) {
         let usage = procOutput.split('\n');
-        let memTotal = parseInt(usage[0]);
-        let memUsed = parseInt(usage[1]);
-        this.percentage = parseInt(usage[2]);
+        let memTotal = this._sanitizeUsageValue(usage[0]);
+        let memUsed = this._sanitizeUsageValue(usage[1]);
+        this.percentage = this._sanitizeUsageValue(usage[2]);
         if (typeof this.useGiB === 'undefined') {
             this._unit(memTotal);
             this._update_unit();

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2173,9 +2173,11 @@ const Gpu = class SystemMonitor_Gpu extends ElementBase {
             global.logError('gpu_usage.sh invocation failed');
         }
     }
-    _sanitizeUsageValue(val){
+    _sanitizeUsageValue(val) {
         val = parseInt(val);
-        if(isNaN(val)){ val = 0 };
+        if (isNaN(val)) {
+            val = 0
+        }
         return val;
     }
     _readTemperature(procOutput) {


### PR DESCRIPTION
avoids NaNs being displayed in widget when script returns unexpected values (e.g GPU is powered down etc)