### PR TITLE
gpu_usage.sh: Remove superfluous function return statement

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/gpu_usage.sh
+++ b/system-monitor@paradoxxx.zero.gmail.com/gpu_usage.sh
@@ -23,7 +23,6 @@
 checkcommand()
 {
 	type $1 > /dev/null 2>&1
-	return "$?"
 }
 
 # This will print three lines. The first one is the the total vRAM available,


### PR DESCRIPTION
From bash's man page: "the exit status of a function is the exit
status of the last command executed in the body".
