### PR TITLE
GPU usage: show usage when using glxinfo output

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/gpu_usage.sh
+++ b/system-monitor@paradoxxx.zero.gmail.com/gpu_usage.sh
@@ -36,4 +36,5 @@ elif checkcommand glxinfo; then
 	let FREEVRAM=TOTALVRAM-AVAILVRAM
 	echo "$TOTALVRAM"
 	echo "$FREEVRAM"
+	echo "scale=2; $FREEVRAM / $TOTALVRAM * 100" | bc
 fi


### PR DESCRIPTION
Previously glxinfo only output total and used memory when using glxinfo, but the nvidia output as well contained usage information, this pull request simply adds that additional third - utilization - data outptu