### PR TITLE
Replace the byte array to utf-8 string conversion routine.

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/convenience.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/convenience.js
@@ -92,3 +92,41 @@ function getSettings(schema) {
 
     return new Gio.Settings({settings_schema: schemaObj});
 }
+
+/**
+ * stringFromUTF8Array:
+ * @byte_array_data: utf-8 string input as a byte array
+ *
+ * Decode the byte array as a proper UTF-8 String.
+ */
+function stringFromUTF8Array(byte_array_data)
+{
+    const extraByteMap = [ 1, 1, 1, 1, 2, 2, 3, 0 ];
+    var count = byte_array_data.length;
+    var str = "";
+
+    for (var index = 0;index < count;)
+    {
+        var ch = byte_array_data[index++];
+        if (ch & 0x80)
+        {
+            var extra = extraByteMap[(ch >> 3) & 0x07];
+            if (!(ch & 0x40) || !extra || ((index + extra) > count))
+                return null;
+
+            ch = ch & (0x3F >> extra);
+            for (;extra > 0;extra -= 1)
+            {
+                var chx = byte_array_data[index++];
+                if ((chx & 0xC0) !== 0x80)
+                    return null;
+
+                ch = (ch << 6) | (chx & 0x3F);
+            }
+        }
+
+        str += String.fromCharCode(ch);
+    }
+
+    return str;
+}

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -40,8 +40,6 @@ const UPower = imports.gi.UPowerGlib;
 // const System = imports.system;
 var ModalDialog = imports.ui.modalDialog;
 
-var ByteArray = imports.byteArray;
-
 var ExtensionSystem = imports.ui.extensionSystem;
 var ExtensionUtils = imports.misc.extensionUtils;
 
@@ -1435,7 +1433,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         let file = Gio.file_new_for_path('/proc/diskstats');
         file.load_contents_async(null, (source, result) => {
             let as_r = source.load_contents_finish(result);
-            let lines = ByteArray.toString(as_r[1]).split('\n');
+            let lines = Convenience.stringFromUTF8Array(as_r[1]).split('\n');
 
             for (let i = 0; i < lines.length; i++) {
                 let line = lines[i];
@@ -2017,7 +2015,8 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
             let file = Gio.file_new_for_path(sfile);
             file.load_contents_async(null, (source, result) => {
                 let as_r = source.load_contents_finish(result)
-                this.temperature = Math.round(parseInt(ByteArray.toString(as_r[1])) / 1000);
+                let thermal_reading = Convenience.stringFromUTF8Array(as_r[1])
+                this.temperature = Math.round(parseInt(thermal_reading) / 1000);
                 if (this.fahrenheit_unit) {
                     this.temperature = Math.round(this.temperature * 1.8 + 32);
                 }
@@ -2088,7 +2087,7 @@ const Fan = class SystemMonitor_Fan extends ElementBase {
             let file = Gio.file_new_for_path(sfile);
             file.load_contents_async(null, (source, result) => {
                 let as_r = source.load_contents_finish(result)
-                this.rpm = parseInt(ByteArray.toString(as_r[1]));
+                this.rpm = parseInt(Convenience.stringFromUTF8Array(as_r[1]));
             });
         } else if (this.display_error) {
             global.logError('error reading: ' + sfile);


### PR DESCRIPTION
This patch fixes the NaN numbers in the monitored stats, like Thermal or Disk.

Reason: The original ByteArray.toString doesn't properly convert
the utf-8 encoded bytes into a string. Neither just calling the String
constructor does the proper decoding.