### PR TITLE
Added the possibility to rearrange the graphs

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2338,19 +2338,34 @@ function enable() {
         };
 
         // Items to Monitor
-        Main.__sm.elts = createCpus();
-        Main.__sm.elts.push(new Freq());
-        Main.__sm.elts.push(new Mem());
-        Main.__sm.elts.push(new Swap());
-        Main.__sm.elts.push(new Net());
-        Main.__sm.elts.push(new Disk());
-        Main.__sm.elts.push(new Gpu());
-        Main.__sm.elts.push(new Thermal());
-        Main.__sm.elts.push(new Fan());
-        Main.__sm.elts.push(new Battery());
-
         let tray = Main.__sm.tray;
         let elts = Main.__sm.elts;
+        
+        // Load the preferred position of the displays and insert them in said order.
+        const positionList = {};
+        // CPUs are inserted differently, so cpu-position is stored apart
+        const cpuPosition = Schema.get_int('cpu-position');
+        positionList[cpuPosition] = createCpus();
+        positionList[Schema.get_int('freq-position')] = new Freq();
+        positionList[Schema.get_int('memory-position')] = new Mem();
+        positionList[Schema.get_int('swap-position')] = new Swap();
+        positionList[Schema.get_int('net-position')] = new Net();
+        positionList[Schema.get_int('disk-position')] = new Disk();
+        positionList[Schema.get_int('gpu-position')] = new Gpu();
+        positionList[Schema.get_int('thermal-position')] = new Thermal();
+        positionList[Schema.get_int('fan-position')] = new Fan();
+        positionList[Schema.get_int('battery-position')] = new Battery();
+
+        for (let i = 0; i < Object.keys(positionList).length; i++) {
+            if (i === cpuPosition) {
+                // CPUs are in an array, store them one by one
+                for (let cpu of positionList[cpuPosition]) {
+                    elts.push(cpu);
+                }
+            } else {
+                elts.push(positionList[i]);
+            }
+        }        
 
         if (Schema.get_boolean('move-clock')) {
             let dateMenu = Main.panel.statusArea.dateMenu;

--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -285,7 +285,15 @@ const SettingFrame = class SystemMonitor {
 
 const App = class SystemMonitor_App {
     constructor() {
-        let setting_items = ['cpu', 'memory', 'swap', 'net', 'disk', 'gpu', 'thermal', 'fan', 'freq', 'battery'];
+        let ordered_items = {};
+        let setting_names = ['cpu', 'memory', 'swap', 'net', 'disk', 'gpu', 'thermal', 'fan', 'freq', 'battery'];
+        let setting_items = [];
+        for (let item of setting_names) {
+            ordered_items[Schema.get_int(item + '-position')] = item;
+        }
+        for (let i = 0; i < Object.keys(ordered_items).length; i++) {
+            setting_items.push(ordered_items[i]);
+        }  
         let keys = Schema.list_keys();
 
         this.items = [];

--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -285,12 +285,14 @@ const SettingFrame = class SystemMonitor {
 
 const App = class SystemMonitor_App {
     constructor() {
-        let ordered_items = {};
         let setting_names = ['cpu', 'memory', 'swap', 'net', 'disk', 'gpu', 'thermal', 'fan', 'freq', 'battery'];
+        let ordered_items = {};
         let setting_items = [];
+        //Get preferred position of the tabs
         for (let item of setting_names) {
             ordered_items[Schema.get_int(item + '-position')] = item;
         }
+        //Populate setting_items with the names in order of preference
         for (let i = 0; i < Object.keys(ordered_items).length; i++) {
             setting_items.push(ordered_items[i]);
         }  
@@ -298,9 +300,11 @@ const App = class SystemMonitor_App {
 
         this.items = [];
         this.settings = [];
+        this.frameToLabel = {}; //Maps Gtk.Widget to the English name of the setting
 
         setting_items.forEach((setting) => {
             this.settings[setting] = new SettingFrame(_(setting.capitalize()), Schema);
+            this.frameToLabel[this.settings[setting].frame] = setting;
         });
 
         this.main_vbox = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL,
@@ -361,12 +365,24 @@ const App = class SystemMonitor_App {
                 }
             }
         });
-        this.notebook = new Gtk.Notebook()
+        
+        this.notebook = new Gtk.Notebook();
+        this.notebook.connect('page-reordered', (widget_, pageNum_) => {
+            // After a page has been moved, update the order preferences
+            for (let i = 0; i < this.notebook.get_n_pages(); i++) {
+                let frame = this.notebook.get_nth_page(i);
+                let name = this.frameToLabel[frame];
+                Schema.set_int(name + "-position", i);
+            }
+        });
+
         setting_items.forEach((setting) => {
             this.notebook.append_page(this.settings[setting].frame, this.settings[setting].label)
+            this.notebook.set_tab_reorderable(this.settings[setting].frame, true);
             this.main_vbox.pack_start(this.notebook, true, true, 0)
             this.main_vbox.show_all();
         });
+
         this.main_vbox.show_all();
     }
 }

--- a/system-monitor@paradoxxx.zero.gmail.com/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
+++ b/system-monitor@paradoxxx.zero.gmail.com/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
@@ -454,6 +454,46 @@
 	  <default>false</default>
 	  <summary>Hide system battery icon</summary>
 	</key>
+  <key name="cpu-position" type="i">
+    <default>0</default>
+    <summary>Position in which to display the CPU display</summary>
+  </key>
+  <key name="freq-position" type="i">
+    <default>1</default>
+    <summary>Position in which to display the frequency display</summary>
+  </key>
+  <key name="memory-position" type="i">
+    <default>2</default>
+    <summary>Position in which to display the memory display</summary>
+  </key>
+  <key name="swap-position" type="i">
+    <default>3</default>
+    <summary>Position in which to display the swap display</summary>
+  </key>
+  <key name="net-position" type="i">
+    <default>4</default>
+    <summary>Position in which to display the net display</summary>
+  </key>
+  <key name="disk-position" type="i">
+    <default>5</default>
+    <summary>Position in which to display the disk display</summary>
+  </key>
+  <key name="gpu-position" type="i">
+    <default>6</default>
+    <summary>Position in which to display the GPU display</summary>
+  </key>
+  <key name="thermal-position" type="i">
+    <default>7</default>
+    <summary>Position in which to display the thermal display</summary>
+  </key>
+  <key name="fan-position" type="i">
+    <default>8</default>
+    <summary>Position in which to display the fan display</summary>
+  </key>
+  <key name="battery-position" type="i">
+    <default>9</default>
+    <summary>Position in which to display the battery display</summary>
+  </key>
 
   </schema>
 </schemalist>


### PR DESCRIPTION
I added some XML attributes and changed some code in `enable()` and the Settings window, making it possible to reorder the graphs (shown in the status bar and the information window) and the settings in the Settings window. This fixes #245 and is a nice feature.

To start rearranging, go to Settings, grab the tab label you wish to move, and drag it to its position. The changes in the order of the tabs are immediate (they will remain the next time the window is opened), but the displays in the status bar will only move after restarting GNOME Shell (`Alt+F2` and the command `r`), although I may be able to work on improving it. The default order is the same as the previous one.

If you have some improvements (a better option than drag and dropping, for instance) or suggestions, feel free to comment!