### PR TITLE
prefs: Remove unused Clutter reference

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -2,7 +2,6 @@ const Gtk = imports.gi.Gtk;
 const Gio = imports.gi.Gio;
 const Gdk = imports.gi.Gdk;
 const GLib = imports.gi.GLib;
-const Clutter = imports.gi.Clutter;
 const ByteArray = imports.byteArray;
 
 const Gettext = imports.gettext.domain('system-monitor');


### PR DESCRIPTION
Preferences are not run in the shell context and should use GTK instead of Clutter.
They actually do but the import was forgotten here.