### PR TITLE
Increased number of files tested in /sys/class/hwmon/

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -44,7 +44,7 @@ function check_sensors(sensor_type) {
     let sensor_list = [];
     let string_list = [];
     let test;
-    for (let j = 0; j < 6; j++) {
+    for (let j = 0; j < 12; j++) {
         for (let k = 0; k < inputs.length; k++) {
             test = sensor_path + 'hwmon' + j + '/' + inputs[k];
             if (!GLib.file_test(test, GLib.FileTest.EXISTS)) {


### PR DESCRIPTION
On my Lenovo X1, there are 12 files in /sys/class/hwmon :

> $ ls /sys/class/hwmon
> hwmon0 hwmon1 hwmon2 hwmon3 hwmon4 hwmon5 hwmon6 hwmon7 hwmon8 hwmon9 hwmon10 hwmon11

The fans are on the 6th one and are then not discovered : I get the "please install lm-sensors" message in settings panel.

> $ ls /sys/class/hwmon/hwmon6
> device subsystem fan2_input pwm1 temp1_input temp3_input temp5_input temp7_input temp9_input temp11_input temp13_input temp15_input uevent
> power fan1_input name pwm1_enable temp2_input temp4_input temp6_input temp8_input temp10_input temp12_input temp14_input temp16_input

Increasing from 6 to 12 fixes the issue.