### PR TITLE
Catch errors when parsing /proc/diskstats (no more NaN)

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1435,7 +1435,12 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         let file = Gio.file_new_for_path('/proc/diskstats');
         file.load_contents_async(null, (source, result) => {
             let as_r = source.load_contents_finish(result);
-            let lines = ByteArray.toString(as_r[1]).split('\n');
+            let lines = [];
+            try {
+                lines = as_r[1].toString().split('\n');
+            } catch (e) {
+                global.logError('Could not split /proc/diskstats string: ' + e);
+            }
 
             for (let i = 0; i < lines.length; i++) {
                 let line = lines[i];


### PR DESCRIPTION
If the disk information cannot be parsed, behave as if there were no information rather than displaying NaN.

Relationships:
- Implements <https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/594#issuecomment-642026009>.
- As far as I know, this should be a workable fix for #594 and #597. 
- This appears to supersede #609.

Thanks for considering this PR!  If you merge it, would you be willing to label it `hacktoberfest-accepted` or give the repo the `hacktoberfest` topic?  [Hacktoberfest is opt-in](https://hacktoberfest.digitalocean.com/hacktoberfest-update) this year.  Thank you also for considering this request!