### PR TITLE
Add units for network speeds over one gigabit

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -203,8 +203,10 @@ const smStyleManager = class SystemMonitor_smStyleManager {
         this._diskunits = _('MiB/s');
         this._netunits_kbytes = _('KiB/s');
         this._netunits_mbytes = _('MiB/s');
+        this._netunits_gbytes = _('GiB/s');
         this._netunits_kbits = _('kbit/s');
         this._netunits_mbits = _('Mbit/s');
+        this._netunits_gbits = _('Gbit/s');
         this._pie_width = 300;
         this._pie_height = 300;
         this._pie_fontsize = 14;
@@ -220,8 +222,10 @@ const smStyleManager = class SystemMonitor_smStyleManager {
             this._diskunits = _('MB');
             this._netunits_kbytes = _('kB');
             this._netunits_mbytes = _('MB');
+            this._netunits_gbytes = _('GB');
             this._netunits_kbits = 'kb';
             this._netunits_mbits = 'Mb';
+            this._netunits_gbits = 'Gb';
             this._pie_width *= 4 / 5;
             this._pie_height *= 4 / 5;
             this._pie_fontsize = 12;
@@ -253,11 +257,17 @@ const smStyleManager = class SystemMonitor_smStyleManager {
     netunits_mbytes() {
         return this._netunits_mbytes;
     }
+    netunits_gbytes() {
+        return this._netunits_gbytes;
+    }
     netunits_kbits() {
         return this._netunits_kbits;
     }
     netunits_mbits() {
         return this._netunits_mbits;
+    }
+    netunits_gbits() {
+        return this._netunits_gbits;
     }
     pie_width() {
         return this._pie_width;
@@ -1803,35 +1813,51 @@ const Net = class SystemMonitor_Net extends ElementBase {
             if (this.tip_vals[0] < 1000) {
                 this.text_items[2].text = Style.netunits_kbits();
                 this.menu_items[1].text = this.tip_unit_labels[0].text = _('kbit/s');
-            } else {
+            } else if (this.tip_vals[0] < 1000000) {
                 this.text_items[2].text = Style.netunits_mbits();
                 this.menu_items[1].text = this.tip_unit_labels[0].text = _('Mbit/s');
                 this.tip_vals[0] = (this.tip_vals[0] / 1000).toPrecision(3);
+            } else {
+                this.text_items[2].text = Style.netunits_gbits();
+                this.menu_items[1].text = this.tip_unit_labels[0].text = _('Gbit/s');
+                this.tip_vals[0] = (this.tip_vals[0] / 1000000).toPrecision(3);
             }
             if (this.tip_vals[2] < 1000) {
                 this.text_items[5].text = Style.netunits_kbits();
                 this.menu_items[4].text = this.tip_unit_labels[2].text = _('kbit/s');
-            } else {
+            } else if (this.tip_vals[2] < 1000000) {
                 this.text_items[5].text = Style.netunits_mbits();
                 this.menu_items[4].text = this.tip_unit_labels[2].text = _('Mbit/s');
                 this.tip_vals[2] = (this.tip_vals[2] / 1000).toPrecision(3);
+            } else {
+                this.text_items[5].text = Style.netunits_gbits();
+                this.menu_items[4].text = this.tip_unit_labels[2].text = _('Gbit/s');
+                this.tip_vals[2] = (this.tip_vals[2] / 1000000).toPrecision(3);
             }
         } else {
             if (this.tip_vals[0] < 1024) {
                 this.text_items[2].text = Style.netunits_kbytes();
                 this.menu_items[1].text = this.tip_unit_labels[0].text = _('KiB/s');
-            } else {
+            } else if (this.tip_vals[0] < 1048576) {
                 this.text_items[2].text = Style.netunits_mbytes();
                 this.menu_items[1].text = this.tip_unit_labels[0].text = _('MiB/s');
                 this.tip_vals[0] = (this.tip_vals[0] / 1024).toPrecision(3);
+            } else {
+                this.text_items[2].text = Style.netunits_gbytes();
+                this.menu_items[1].text = this.tip_unit_labels[0].text = _('GiB/s');
+                this.tip_vals[0] = (this.tip_vals[0] / 1048576).toPrecision(3);
             }
             if (this.tip_vals[2] < 1024) {
                 this.text_items[5].text = Style.netunits_kbytes();
                 this.menu_items[4].text = this.tip_unit_labels[2].text = _('KiB/s');
-            } else {
+            } else if (this.tip_vals[2] < 1048576) {
                 this.text_items[5].text = Style.netunits_mbytes();
                 this.menu_items[4].text = this.tip_unit_labels[2].text = _('MiB/s');
                 this.tip_vals[2] = (this.tip_vals[2] / 1024).toPrecision(3);
+            } else {
+                this.text_items[5].text = Style.netunits_gbytes();
+                this.menu_items[4].text = this.tip_unit_labels[2].text = _('GiB/s');
+                this.tip_vals[2] = (this.tip_vals[2] / 1048576).toPrecision(3);
             }
         }
 


### PR DESCRIPTION
Currently the display falls back to scientific notation, which isn't really that useful.