### PR TITLE
Fix “GNOME Shell” and “information” spelling

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/metadata.json
+++ b/system-monitor@paradoxxx.zero.gmail.com/metadata.json
@@ -3,7 +3,7 @@
     "uuid": "system-monitor@paradoxxx.zero.gmail.com",
     "name": "system-monitor",
     "url": "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet",
-    "description": "Display system informations in gnome shell status bar, such as memory usage, cpu usage, network rates…",
+    "description": "Display system information in GNOME Shell status bar, such as memory, CPU, disk and battery usages, network rates…",
     "settings-schema":  "org.gnome.shell.extensions.system-monitor",
     "gettext-domain": "system-monitor",
     "version": -1


### PR DESCRIPTION
“GNOME Shell” is the official spelling
“Information” is an uncountable noun in English: https://dictionary.cambridge.org/us/dictionary/english/information
Add battery and disk to the list of the information reported by the extension