### PR TITLE
Fix README.md (remove remaining Unicode chars...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,37 +12,38 @@
 
 #### Prerequisites
 
-This extension [requires GNOME Shell v3.26 or later](https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/blob/master/system-monitor%40paradoxxx.zero.gmail.com/metadata.json#L2).
-Please see the alternate branches [gnome-3.0](https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/tree/gnome-3.0) and [gnome-3.2](https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/tree/gnome-3.2) if you are using an older version of GNOME Shell (check with `gnome-shell --version`).
+This extension [requires GNOME Shell v3.26 or later](https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/blob/master/system-monitor%40paradoxxx.zero.gmail.com/metadata.json#L2).
 
 Before installing this extension, ensure you have the necessary system packages installed:
 
 * On Ubuntu:
 
       $ sudo apt install gir1.2-gtop-2.0 gir1.2-nm-1.0 gir1.2-clutter-1.0 gnome-system-monitor
-      
+
 * On Debian:
 
       $ sudo apt install gir1.2-gtop-2.0 gir1.2-nm-1.0 gir1.2-clutter-1.0 gnome-system-monitor
 
 * On Fedora:
 
-      $ dnf install libgtop2-devel NetworkManager-libnm-devel
+      $ sudo dnf install libgtop2-devel NetworkManager-libnm-devel
 
+* On Arch Linux:
 
-    
+      $ sudo pacman -S libgtop networkmanager
+
 * On openSUSE (Leap 42.1):
 
       $ sudo zypper install gnome-shell-devel libgtop-devel libgtop-2_0-10 gnome-system-monitor
 
-* On Mageia 64-bit (just remove “64” on i586):
+* On Mageia 64-bit (just remove "64" on i586):
 
       $ sudo urpmi lib64gtop-gir2.0 lib64nm-gir1.0 lib64clutter-gir1.0 gnome-system-monitor
-      
+
     or
-      
+
       $ sudo dnf install lib64gtop-gir2.0 lib64nm-gir1.0 lib64clutter-gir1.0 gnome-system-monitor
-      
+
 
 Additionally, if you have an NVIDIA graphics card, and want to monitor its memory usage, you'll need to install `nvidia-smi`.
 
@@ -51,8 +52,8 @@ For the browser installation (recommended), you will need the GNOME Shell integr
 [Firefox](https://addons.mozilla.org/en-US/firefox/addon/gnome-shell-integration/) or
 [Opera](https://addons.opera.com/en/extensions/details/gnome-shell-integration/).
 
-Note: If you're using Firefox 52 or later, [you will also need to install `chrome-gnome-shell`](https://blogs.gnome.org/ne0sight/2016/12/25/how-to-install-gnome-shell-extensions-with-firefox-52/).
-The instructions are available [on the GNOME wiki](https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome/Installation#Ubuntu_Linux).
+Note: If you're using Firefox 52 or later, [you will also need to install `chrome-gnome-shell`](https://blogs.gnome.org/ne0sight/2016/12/25/how-to-install-gnome-shell-extensions-with-firefox-52/).
+The instructions are available [on the GNOME wiki](https://wiki.gnome.org/Projects/GnomeShellIntegrationForChrome/Installation#Ubuntu_Linux).
 
 #### Browser installation
 
@@ -61,10 +62,10 @@ It's recommended you install the extension via the Gnome Shell Extensions websit
 Visit [this extension's page on extensions.gnome.org](https://extensions.gnome.org/extension/120/system-monitor/),
 preferably in Firefox, and install by clicking the toggle button next to the extension's name.
 
-If the install was successful, the toggle button should now show “ON”.
+If the install was successful, the toggle button should now show "ON".
 If it failed, ensure that you installed all the [necessary dependencies](#prerequisites),
 and that you granted the browser permission to install extensions when prompted.
-Additionally, rebooting gnome-shell may help (type `Alt + F2` and input `r` in the prompt), but it won't work with Wayland.
+Additionally, rebooting gnome-shell may help (type `Alt + F2` and input `r` in the prompt), but it won't work with Wayland.
 
 #### Repository installation
 
@@ -81,7 +82,7 @@ extract the archive, open a shell into its directory, and run:
 
     make install
 
-Alternately, if you plan on doing development on the extension, or testing modifications, it's advised you checkout the Git repository and install a symlink. First, install git if you don’t have it: (`sudo apt-get install git-core`, `sudo pacman -S git`, etc.), then run:
+Alternately, if you plan on doing development on the extension, or testing modifications, it's advised you checkout the Git repository and install a symlink. First, install git if you don't have it: (`sudo apt-get install git-core`, `sudo pacman -S git`, etc.), then run:
 
     GIT_PROJECTS=~/git_projects
     PROJECT_NAME=system-monitor@paradoxxx.zero.gmail.com
@@ -114,7 +115,7 @@ If we do not have the translation for your language and you want to translate it
 
 To determine the version number to use, check the extensions site and increment from the largest published version.
 
-The specified version number is just for documentation and isn’t strictly necessary in the uploaded file, since the extensions website will dynamically set this and override whatever we enter.
+The specified version number is just for documentation and isn't strictly necessary in the uploaded file, since the extensions website will dynamically set this and override whatever we enter.
 
 2. Once uploaded, [create a GitHub release](https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/releases) with the same version number.
 
@@ -131,13 +132,13 @@ Copyright (C) 2011 Florian Mounier aka paradoxxxzero
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
+the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <http://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Before installing this extension, ensure you have the necessary system packages 
 
 * On Fedora:
 
-      $ sudo dnf install libgtop2-devel NetworkManager-libnm-devel
+      $ sudo dnf install libgtop2-devel NetworkManager-libnm-devel gnome-system-monitor
 
 * On Arch Linux:
 
-      $ sudo pacman -S libgtop networkmanager
+      $ sudo pacman -S libgtop networkmanager gnome-system-monitor
 
 * On openSUSE (Leap 42.1):
 


### PR DESCRIPTION
Improve the README.md (fix remaining UTF-8 chars)

- Fix the removing of remaining apostrophes and UTF-8 chars (quotes and non-breaking spaces)
- Add Arch Linux install information for consistency with extension.js
- Remove information about outdated GNOME 3.0 and GNOME 3.2.

