### PR TITLE
add backward support for Gnome 3.28 , fix NaN temperature and disk IO…

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -107,6 +107,13 @@ Clutter.Actor.prototype.reparent = function reparent(newParent) {
     newParent.add_child(this);
 }
 
+function parse_bytearray(bytearray) {
+    if (!ByteArray.toString(bytearray).match(/GjsModule byteArray/)) {
+        return ByteArray.toString(bytearray);
+    }
+    return bytearray
+}
+
 function l_limit(t) {
     return (t > 0) ? t : 1000;
 }
@@ -1437,7 +1444,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
         let file = Gio.file_new_for_path('/proc/diskstats');
         file.load_contents_async(null, (source, result) => {
             let as_r = source.load_contents_finish(result);
-            let lines = ByteArray.toString(as_r[1]).split('\n');
+            let lines = parse_bytearray(as_r[1]).toString().split('\n');
 
             for (let i = 0; i < lines.length; i++) {
                 let line = lines[i];
@@ -2019,7 +2026,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
             let file = Gio.file_new_for_path(sfile);
             file.load_contents_async(null, (source, result) => {
                 let as_r = source.load_contents_finish(result)
-                this.temperature = Math.round(parseInt(ByteArray.toString(as_r[1])) / 1000);
+                this.temperature = Math.round(parseInt(parse_bytearray(as_r[1])) / 1000);
                 if (this.fahrenheit_unit) {
                     this.temperature = Math.round(this.temperature * 1.8 + 32);
                 }
@@ -2090,7 +2097,7 @@ const Fan = class SystemMonitor_Fan extends ElementBase {
             let file = Gio.file_new_for_path(sfile);
             file.load_contents_async(null, (source, result) => {
                 let as_r = source.load_contents_finish(result)
-                this.rpm = parseInt(ByteArray.toString(as_r[1]));
+                this.rpm = parseInt(parse_bytearray(as_r[1]));
             });
         } else if (this.display_error) {
             global.logError('error reading: ' + sfile);


### PR DESCRIPTION
… on Ubuntu 18.04

add backward support for Gnome 3.28 , fix NaN temperature and disk IO on Ubuntu 18.04 . 

related issues: #520 #526 #594 #597 #601  https://github.com/thankjura/ds4battery/issues/4  
I don't have dedicated GPU to test #592 but it should be possible to fix in the same way.

inspired by @shemgp and @EBoisseauSierra