### PR TITLE
update prefs to support gnome 40

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -725,15 +725,15 @@ const TipMenu = class SystemMonitor_TipMenu extends PopupMenu.PopupMenuBase {
 
         let sourceTopLeftX = 0;
         let sourceTopLeftY = 0;
-        if (typeof this.sourceActor.get_transformed_extents === "function") {
-                let extents = this.sourceActor.get_transformed_extents();
-                let sourceTopLeft = extents.get_top_left();
-                sourceTopLeftY = sourceTopLeft.y;
-                sourceTopLeftX = sourceTopLeft.x;
+        if (typeof this.sourceActor.get_transformed_extents === 'function') {
+            let extents = this.sourceActor.get_transformed_extents();
+            let sourceTopLeft = extents.get_top_left();
+            sourceTopLeftY = sourceTopLeft.y;
+            sourceTopLeftX = sourceTopLeft.x;
         } else {
-                let allocation = Shell.util_get_transformed_allocation(this.sourceActor);
-                sourceTopLeftY = allocation.y1;
-                sourceTopLeftX = allocation.x1;
+            let allocation = Shell.util_get_transformed_allocation(this.sourceActor);
+            sourceTopLeftY = allocation.y1;
+            sourceTopLeftX = allocation.x1;
         }
         let monitor = Main.layoutManager.findMonitorForActor(this.sourceActor);
         let [x, y] = [sourceTopLeftX + contentbox.x1,

--- a/system-monitor@paradoxxx.zero.gmail.com/metadata.json
+++ b/system-monitor@paradoxxx.zero.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.26", "3.28", "3.30", "3.32", "3.34", "3.36"],
+    "shell-version": ["3.26", "3.28", "3.30", "3.32", "3.34", "3.36", "40"],
     "uuid": "system-monitor@paradoxxx.zero.gmail.com",
     "name": "system-monitor",
     "url": "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet",

--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -69,39 +69,52 @@ function check_sensors(sensor_type) {
     return [sensor_list, string_list];
 }
 
-function box(isHorizontal, spacing, hasBorder) {
+/**
+ * @param args.hasBorder Whether the box has a border (true) or not
+ * @param args.horizontal Whether the box is horizontal (true)
+ *      or vertical (false)
+ * @param args.shouldPack Determines whether a horizontal box should have
+ *      uniform spacing for its children. Only applies to horizontal boxes
+ * @param args.spacing The amount of spacing for a given box
+ * @returns a new Box with settings specified by args
+ */
+function box(args = {}) {
     const options = { };
 
-    if (typeof spacing !== 'undefined') {
-        options.spacing = spacing;
+    if (typeof args.spacing !== 'undefined') {
+        options.spacing = args.spacing;
     }
 
     if (shellMajorVersion < 40) {
-        if (hasBorder) {
+        if (args.hasBorder) {
             options.border_width = 10;
         }
 
-        return isHorizontal ? new Gtk.HBox(options) : new Gtk.VBox(options);
+        return args.horizontal ?
+            new Gtk.HBox(options) : new Gtk.VBox(options);
     }
 
-    if (hasBorder) {
+    if (args.hasBorder) {
         options.margin_top = 10;
         options.margin_bottom = 10;
         options.margin_start = 10;
         options.margin_end = 10;
     }
 
-    options.orientation = isHorizontal ?
+    options.orientation = args.horizontal ?
         Gtk.Orientation.HORIZONTAL : Gtk.Orientation.VERTICAL;
 
     const aliasBox = new Gtk.Box(options);
 
-    if (isHorizontal) {
+    if (args.shouldPack) {
         aliasBox.set_homogeneous(true);
     }
 
+
     aliasBox.add = aliasBox.append;
     aliasBox.pack_start = aliasBox.prepend;
+    // normally, this would be append; it is aliased to prepend because
+    // that appears to yield the same behavior as version < 40
     aliasBox.pack_end = aliasBox.prepend;
 
     return aliasBox;
@@ -111,7 +124,7 @@ const ColorSelect = class SystemMonitor_ColorSelect {
     constructor(name) {
         this.label = new Gtk.Label({label: name + _(':')});
         this.picker = new Gtk.ColorButton();
-        this.actor = box(true, 5);
+        this.actor = box({horizontal: true, spacing: 5});
         this.actor.add(this.label);
         this.actor.add(this.picker);
         this.picker.set_use_alpha(true);
@@ -129,7 +142,7 @@ const IntSelect = class SystemMonitor_IntSelect {
     constructor(name) {
         this.label = new Gtk.Label({label: name + _(':')});
         this.spin = new Gtk.SpinButton();
-        this.actor = box(true);
+        this.actor = box({horizontal: true, shouldPack: true, });
         this.actor.add(this.label);
         this.actor.add(this.spin);
         this.spin.set_numeric(true);
@@ -148,7 +161,7 @@ const Select = class SystemMonitor_Select {
         this.label = new Gtk.Label({label: name + _(':')});
         // this.label.set_justify(Gtk.Justification.RIGHT);
         this.selector = new Gtk.ComboBoxText();
-        this.actor = box(true, 5);
+        this.actor = box({horizontal: true, shouldPack: true, spacing: 5});
         this.actor.add(this.label);
         this.actor.add(this.selector);
     }
@@ -179,11 +192,11 @@ const SettingFrame = class SystemMonitor {
         this.schema = schema;
         this.label = new Gtk.Label({label: name});
 
-        this.vbox = box(false, 20);
-        this.hbox0 = box(true, 20);
-        this.hbox1 = box(true, 20);
-        this.hbox2 = box(true, 20);
-        this.hbox3 = box(true, 20);
+        this.vbox = box({horizontal: false, shouldPack: true, spacing: 20});
+        this.hbox0 = box({horizontal: true, shouldPack: true, spacing: 20});
+        this.hbox1 = box({horizontal: true, shouldPack: true, spacing: 20});
+        this.hbox2 = box({horizontal: true, shouldPack: true, spacing: 20});
+        this.hbox3 = box({horizontal: true, shouldPack: true, spacing: 20});
 
         if (shellMajorVersion < 40) {
             this.frame = new Gtk.Frame({border_width: 10});
@@ -382,8 +395,10 @@ const App = class SystemMonitor_App {
             this.settings[setting] = new SettingFrame(_(setting.capitalize()), Schema);
         });
 
-        this.main_vbox = box(false, 10, true);
-        this.hbox1 = box(true, 20, true);
+        this.main_vbox = box({
+            hasBorder: true, horizontal: false, spacing: 10});
+        this.hbox1 = box({
+            hasBorder: true, horizontal: true, shouldPack: true, spacing: 20});
         this.main_vbox.pack_start(this.hbox1, false, false, 0);
 
         keys.forEach((key) => {

--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -111,7 +111,7 @@ const ColorSelect = class SystemMonitor_ColorSelect {
     constructor(name) {
         this.label = new Gtk.Label({label: name + _(':')});
         this.picker = new Gtk.ColorButton();
-        this.actor = box(5);
+        this.actor = box(true, 5);
         this.actor.add(this.label);
         this.actor.add(this.picker);
         this.picker.set_use_alpha(true);


### PR DESCRIPTION
Hopefully addreses #672 

Gtk4 introduced breaking changes to how the preferences are created. This PR seeks to handle those changes while maintaining backwards compatibility
-  Gtk.HBox and Gtk.VBox are dead, replaced with Gtk.Box with orientation 
- `border_width` is dead, replace it with margins of 10 (this seems to function similarly)
- `add`, `pack_start`, `pack_end` calls for Box have been replaced with `append` and `prepend`: these calls are aliased where appropriate
- Because packing is gone, spacing is now controlled by `set_homogeneous`; It has bigger windows and boxes, but seems to be the closest to maintaining packing?
- `show_all` is unneeded in new versions
- `get_all_children` is gone, so I use effectively an iterator to build and sort the array

Additionally fixes complaints in `extension.js` from eslint.

Tested on fedora 34, arch linux (in English, for ordering).

I'm not sure if this is the best/cleanest way to multiplex, but hopefully it is at least a good start?