### PR TITLE
Add GitHub CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  # For more information on GitHub's ShellCheck Action:
+  # https://github.com/marketplace/actions/shellcheck
+  # For more information on shellcheck failures:
+  # https://github.com/koalaman/shellcheck/wiki/Checks
+  shellcheck:
+    name: shellcheck
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: shellcheck
+      uses: ludeeus/action-shellcheck@master
+      with:
+        # When/if all warnings are fixed, remove this to use the default
+        # behavior to fail (already) on warnings instead:
+        severity: error


### PR DESCRIPTION
GitHub's CI pipeline makes it very simple to rapidly set up powerful checks for one's code tree.
This PR adds such a pipeline to this project, beginning with the GitHub shellcheck action.
(Currently set to only fail on errors, and not the default behavior to fail on warnings too since there are a handful of scripts that currently do not pass shellcheck as-is with shellcheck's default behavior.)