### PR TITLE
Add GUI testing proof-of-concept

### DIFF
--- a/Dockerfile.ubuntu2004
+++ b/Dockerfile.ubuntu2004
@@ -102,5 +102,14 @@ RUN mkdir -p $HOME/.vnc
 COPY xstartup $HOME/.vnc/xstartup
 RUN echo "password" | vncpasswd -f >> $HOME/.vnc/passwd && chmod 600 $HOME/.vnc/passwd
 
+# Set up GUI testing environment
+RUN sudo apt-get update \
+    && sudo apt-get install -y python3-pip \
+    && sudo apt-get clean -y \
+    && sudo rm -rf /var/lib/apt/lists/*
+RUN pip3 install --user dogtail
+RUN chmod +x "/home/${USER}/.local/bin"/*
+RUN echo "export PATH=\"\$PATH:/home/${USER}/.local/bin\"" >> "/home/${USER}/.bashrc"
+
 # Switch back to root to start systemd.
 USER root

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -3,5 +3,6 @@ docker run -it --name=ubuntu-gnome --rm \
     --tmpfs /run --tmpfs /run/lock --tmpfs /tmp \
     --cap-add SYS_BOOT --cap-add SYS_ADMIN \
     -v /sys/fs/cgroup:/sys/fs/cgroup \
+    -v "$(pwd)/testing:/home/default/shared" \
     -p 5901:5901 -p 6901:6901 \
     gnome-shell-system-monitor-applet

--- a/testing/run_gui_tests.sh
+++ b/testing/run_gui_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+gsettings set org.gnome.desktop.interface toolkit-accessibility true
+python3 test_gui.py

--- a/testing/test_gui.py
+++ b/testing/test_gui.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+from dogtail import logging, predicate, rawinput, tree, utils
+
+# Roles
+ROLE_FILLER = "filler"
+ROLE_FRAME = "frame"
+ROLE_LABEL = "label"
+ROLE_MENU_ITEM = "menu item"
+ROLE_PANEL = "panel"
+ROLE_PUSH_BUTTON = "push button"
+ROLE_TOGGLE_BUTTON = "toggle button"
+ROLE_WINDOW = "window"
+
+
+# start gnome-tweaks
+utils.run("gnome-tweaks")
+
+# click on Extensions label
+tweaks_node = tree.root.application("gnome-tweaks")
+tweaks_node \
+    .child(name="Extensions", roleName=ROLE_LABEL) \
+    .click()
+
+# enable applet
+applet_text_node = tweaks_node.child(name="System-monitor", roleName=ROLE_LABEL)
+toggle_button_node = applet_text_node \
+    .findAncestor(predicate.GenericPredicate(roleName=ROLE_FILLER)) \
+    .findAncestor(predicate.GenericPredicate(roleName=ROLE_FILLER)) \
+    .child(roleName=ROLE_TOGGLE_BUTTON)
+if not toggle_button_node.isChecked:
+    toggle_button_node.click()
+
+# close gnome-tweaks
+tweaks_node \
+    .child(name="Close", roleName=ROLE_PUSH_BUTTON) \
+    .click()
+
+# click on the graphical widget
+shell_window_node = tree.root.application("gnome-shell") \
+    .child(roleName=ROLE_WINDOW)
+panel_node = shell_window_node \
+    .child(name="Cpu", roleName=ROLE_LABEL) \
+    .findAncestor(predicate.GenericPredicate(roleName=ROLE_PANEL))
+applet_position = ((shell_window_node.size[0] - 100), 0) # approximation
+rawinput.click(*applet_position)
+
+# find the cpu value
+strings = panel_node.getUserVisibleStrings()
+cpu_idx = strings.index("Cpu") + 1
+cpu_value = int(strings[cpu_idx])
+assert cpu_value >= 0
+logging.debugLogger.log(f"{cpu_value=}")
+
+# open applet preference dialog
+perference_menu_item_node = panel_node \
+    .findAncestor(predicate.GenericPredicate(roleName=ROLE_PANEL)) \
+    .findAncestor(predicate.GenericPredicate(roleName=ROLE_PANEL)) \
+    .child(name="Preferences...", roleName=ROLE_LABEL) \
+    .findAncestor(predicate.GenericPredicate(roleName=ROLE_MENU_ITEM))
+rawinput.click(*perference_menu_item_node.position)
+
+# close applet preference dialog
+applet_preference_panel = tree.root.application("org.gnome.Shell.Extensions") \
+    .child(name="system-monitor", roleName=ROLE_FRAME) \
+    .child(roleName=ROLE_PANEL)
+rawinput.click(*applet_preference_panel.position)  # activate dialog
+applet_preference_panel \
+    .child(name="Close", roleName=ROLE_PUSH_BUTTON) \
+    .click()


### PR DESCRIPTION
Closes #663.

The [dogtail](https://gitlab.com/dogtail/dogtail) test tool is used to write the tests as suggested in the linked issue.
The tests run inside the docker image, steps:
```shell
# build new image
./build-docker.sh

# startup
./run-docker.sh
./open-docker.sh

# running GUI tests
# open terminal within docker container and then
cd /home/default/shared
./run_gui_tests.sh

# shutdown
./close-docker.sh
```