### PR TITLE
Add support for display scale factor

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -398,21 +398,17 @@ const Chart = class SystemMonitor_Chart {
         }
         cr.$dispose();
     }
-    resize(schema, key) {
-        let old_width = this.width;
-        this.width = Schema.get_int(key);
-        if (old_width === this.width) {
+    resize(width) {
+        if (this.width === width) {
             return;
         }
-        if (Style.get('') === '-compact') {
-            this.width = Math.round(this.width / 1.5);
-        }
-        this.actor.set_width(this.width);
+        this.width = width;
         if (this.width < this.data[0].length) {
             for (let i = 0; i < this.parentC.colors.length; i++) {
                 this.data[i] = this.data[i].slice(-this.width);
             }
         }
+        this.actor.set_width(this.width); // repaints
     }
 }
 
@@ -928,8 +924,7 @@ const ElementBase = class SystemMonitor_ElementBase extends TipBox {
                 this.timeout = Mainloop.timeout_add(
                     this.interval, this.update.bind(this), GLib.PRIORITY_DEFAULT_IDLE);
             });
-        Schema.connect('changed::' + this.elt + '-graph-width',
-            this.chart.resize.bind(this.chart));
+        Schema.connect('changed::' + this.elt + '-graph-width', this.resize.bind(this));
 
         if (this.elt === 'thermal') {
             Schema.connect('changed::thermal-threshold',
@@ -1019,6 +1014,13 @@ const ElementBase = class SystemMonitor_ElementBase extends TipBox {
                 this.text_items[0].set_style('color: rgba(255, 255, 255, 1)');
             }
         }
+    }
+    resize(schema, key) {
+        let width = Schema.get_int(key);
+        if (Style.get('') === '-compact') {
+            width = Math.round(width / 1.5);
+        }
+        this.chart.resize(width);
     }
     destroy() {
         TipBox.prototype.destroy.call(this);

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -214,11 +214,9 @@ const smStyleManager = class SystemMonitor_smStyleManager {
         this._netunits_kbits = _('kbit/s');
         this._netunits_mbits = _('Mbit/s');
         this._netunits_gbits = _('Gbit/s');
-        this._pie_width = 300;
-        this._pie_height = 300;
+        this._pie_size = 300;
         this._pie_fontsize = 14;
         this._bar_width = 300;
-        this._bar_height = 150;
         this._bar_thickness = 15;
         this._bar_fontsize = 14;
         this._compact = Schema.get_boolean('compact-display');
@@ -233,11 +231,9 @@ const smStyleManager = class SystemMonitor_smStyleManager {
             this._netunits_kbits = 'kb';
             this._netunits_mbits = 'Mb';
             this._netunits_gbits = 'Gb';
-            this._pie_width *= 4 / 5;
-            this._pie_height *= 4 / 5;
+            this._pie_size *= 4 / 5;
             this._pie_fontsize = 12;
             this._bar_width *= 3 / 5;
-            this._bar_height *= 3 / 5;
             this._bar_thickness = 12;
             this._bar_fontsize = 12;
         }
@@ -269,20 +265,14 @@ const smStyleManager = class SystemMonitor_smStyleManager {
     netunits_gbits() {
         return this._netunits_gbits;
     }
-    pie_width() {
-        return this._pie_width;
-    }
-    pie_height() {
-        return this._pie_height;
+    pie_size() {
+        return this._pie_size;
     }
     pie_fontsize() {
         return this._pie_fontsize;
     }
     bar_width() {
         return this._bar_width;
-    }
-    bar_height() {
-        return this._bar_height;
     }
     bar_thickness() {
         return this._bar_thickness;
@@ -610,8 +600,9 @@ const Graph = class SystemMonitor_Graph {
 }
 
 const Bar = class SystemMonitor_Bar extends Graph {
-    constructor(width, height) {
-        super(width, height);
+    constructor() {
+        // Height doesn't matter, it gets set on every draw.
+        super(Style.bar_width(), 100);
         this.mounts = MountsMonitor.get_mounts();
         MountsMonitor.add_listener(this.update_mounts.bind(this));
     }
@@ -658,8 +649,8 @@ const Bar = class SystemMonitor_Bar extends Graph {
 }
 
 const Pie = class SystemMonitor_Pie extends Graph {
-    constructor(width, height) {
-        super(width, height);
+    constructor() {
+        super(Style.pie_size(), Style.pie_size());
         this.mounts = MountsMonitor.get_mounts();
         MountsMonitor.add_listener(this.update_mounts.bind(this));
     }
@@ -2438,8 +2429,8 @@ function enable() {
         Main.__sm = {
             tray: new PanelMenu.Button(0.5),
             icon: new Icon(),
-            pie: new Pie(Style.pie_width(), Style.pie_height()), // 300, 300
-            bar: new Bar(Style.bar_width(), Style.bar_height()), // 300, 150
+            pie: new Pie(),
+            bar: new Bar(),
             elts: [],
         };
 

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -219,6 +219,7 @@ const smStyleManager = class SystemMonitor_smStyleManager {
         this._pie_fontsize = 14;
         this._bar_width = 300;
         this._bar_height = 150;
+        this._bar_thickness = 15;
         this._bar_fontsize = 14;
         this._compact = Schema.get_boolean('compact-display');
 
@@ -237,6 +238,7 @@ const smStyleManager = class SystemMonitor_smStyleManager {
             this._pie_fontsize = 12;
             this._bar_width *= 3 / 5;
             this._bar_height *= 3 / 5;
+            this._bar_thickness = 12;
             this._bar_fontsize = 12;
         }
     }
@@ -281,6 +283,9 @@ const smStyleManager = class SystemMonitor_smStyleManager {
     }
     bar_height() {
         return this._bar_height;
+    }
+    bar_thickness() {
+        return this._bar_thickness;
     }
     bar_fontsize() {
         return this._bar_fontsize;
@@ -614,7 +619,7 @@ const Bar = class SystemMonitor_Bar extends Graph {
         if (!this.actor.visible) {
             return;
         }
-        let thickness = 15 * this.scale_factor * this.text_scaling;
+        let thickness = Style.bar_thickness() * this.scale_factor * this.text_scaling;
         let fontsize = Style.bar_fontsize() * this.scale_factor * this.text_scaling;
         this.actor.set_height(this.mounts.length * (3 * thickness));
         let [width, height] = this.actor.get_surface_size();

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -700,14 +700,18 @@ const Pie = class SystemMonitor_Pie extends Graph {
             GTop.glibtop_get_fsusage(this.gtop, this.mounts[mount]);
             Clutter.cairo_set_source_color(cr, this.colors[mount % this.colors.length]);
             arc(r, this.gtop.blocks - this.gtop.bfree, this.gtop.blocks, -pi / 2);
-            cr.moveTo(0, yc - r + fontsize / 2);
+            cr.stroke();
+            r -= ring_width;
+        }
+        let y = (ring_width + fontsize) / 2;
+        for (let mount in this.mounts) {
             var text = this.mounts[mount];
             if (text.length > 10) {
                 text = text.split('/').pop();
             }
+            cr.moveTo(0, y);
             cr.showText(text);
-            cr.stroke();
-            r -= ring_width;
+            y += ring_width;
         }
         cr.$dispose();
     }

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -573,8 +573,8 @@ const Graph = class SystemMonitor_Graph {
             this.text_scaling = 1;
         }
 
-        this.actor.set_width(this.width * this.scale_factor);
-        this.actor.set_height(this.height * this.scale_factor);
+        this.actor.set_width(this.width * this.scale_factor * this.text_scaling);
+        this.actor.set_height(this.height * this.scale_factor * this.text_scaling);
         this.actor.connect('repaint', this._draw.bind(this));
     }
     create_menu_item() {
@@ -591,16 +591,16 @@ const Graph = class SystemMonitor_Graph {
     }
     set_scale(themeContext) {
         this.scale_factor = themeContext.scale_factor;
-        this.actor.set_width(this.width * this.scale_factor);
-        this.actor.set_height(this.height * this.scale_factor);
+        this.actor.set_width(this.width * this.scale_factor * this.text_scaling);
+        this.actor.set_height(this.height * this.scale_factor * this.text_scaling);
     }
     set_text_scaling(interfaceSettings, key) {
         // FIXME: for some reason we only get this signal once, not on later
         // changes to the setting
         //log('[System monitor] got text scaling signal');
         this.text_scaling = interfaceSettings.get_double(key);
-        this.actor.set_width(this.width * this.scale_factor);
-        this.actor.set_height(this.height * this.scale_factor);
+        this.actor.set_width(this.width * this.scale_factor * this.text_scaling);
+        this.actor.set_height(this.height * this.scale_factor * this.text_scaling);
     }
 }
 

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -391,14 +391,26 @@ const Chart = class SystemMonitor_Chart {
         cr.rectangle(0, 0, width, height);
         cr.fill();
         for (let i = this.parentC.colors.length - 1; i >= 0; i--) {
-            cr.moveTo(width, height);
-            for (let j = this.data[i].length - 1; j >= 0; j--) {
-                cr.lineTo(width - (this.data[i].length - 1 - j), (1 - this.data[i][j] / max) * height);
+            let samples = this.data[i].length - 1;
+            if (samples > 0) {
+                cr.moveTo(width, height); // bottom right
+                let x = width - 0.25 * this.scale_factor;
+                cr.lineTo(x, (1 - this.data[i][samples] / max) * height);
+                x -= 0.5 * this.scale_factor;
+                for (let j = samples; j >= 0; j--) {
+                    let y = (1 - this.data[i][j] / max) * height;
+                    cr.lineTo(x, y);
+                    x -= 0.5 * this.scale_factor;
+                    cr.lineTo(x, y);
+                    x -= 0.5 * this.scale_factor;
+                }
+                x += 0.25 * this.scale_factor;
+                cr.lineTo(x, (1 - this.data[i][0] / max) * height);
+                cr.lineTo(x, height);
+                cr.closePath();
+                Clutter.cairo_set_source_color(cr, this.parentC.colors[i]);
+                cr.fill();
             }
-            cr.lineTo(width - (this.data[i].length - 1), height);
-            cr.closePath();
-            Clutter.cairo_set_source_color(cr, this.parentC.colors[i]);
-            cr.fill();
         }
         cr.$dispose();
     }

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -344,13 +344,17 @@ const Chart = class SystemMonitor_Chart {
     constructor(width, height, parent) {
         this.actor = new St.DrawingArea({style_class: Style.get('sm-chart'), reactive: false});
         this.parentC = parent;
-        this.actor.set_width(this.width = width);
-        this.actor.set_height(this.height = height);
-        this.actor.connect('repaint', this._draw.bind(this));
+        this.width = width;
+        let themeContext = St.ThemeContext.get_for_stage(global.stage);
+        this.scale_factor = themeContext.scale_factor;
+        this.actor.set_width(this.width * this.scale_factor);
+        this.actor.set_height(height);
         this.data = [];
         for (let i = 0; i < this.parentC.colors.length; i++) {
             this.data[i] = [];
         }
+        themeContext.connect('notify::scale-factor', this.rescale.bind(this));
+        this.actor.connect('repaint', this._draw.bind(this));
     }
     update() {
         let data_a = this.parentC.vals;
@@ -408,7 +412,11 @@ const Chart = class SystemMonitor_Chart {
                 this.data[i] = this.data[i].slice(-this.width);
             }
         }
-        this.actor.set_width(this.width); // repaints
+        this.actor.set_width(this.width * this.scale_factor); // repaints
+    }
+    rescale(themeContext) {
+        this.scale_factor = themeContext.scale_factor;
+        this.actor.set_width(this.width * this.scale_factor); // repaints
     }
 }
 


### PR DESCRIPTION
Not all parts of the interface follow the display scale setting on a high dpi monitor. Text is scaled automatically, but the graphs, pie chart and bar chart remained tiny.

This is my attempt to have those elements use the right scale factor. It is only read once, you have to restart the extension or Gnome Shell after changing the monitor scale factor.

(Also, this is my first time touching Javascript and Gnome Shell extensions.)

This should fix https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/525, although that issue is a bit vague. Fixes https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/613.