### PR TITLE
Small fixes to thermal monitoring

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2113,7 +2113,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
         return this.temperature.toString();
     }
     temperature_symbol() {
-        return this.fahrenheit_unit ? '\u2109' : '\u2103';
+        return this.fahrenheit_unit ? '°F' : '°C';
     }
 }
 

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2076,8 +2076,6 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
     }
     _apply() {
         this.text_items[0].text = this.menu_items[0].text = this.temperature_text();
-        // Making it looks better in chart.
-        // this.vals = [this.temperature / 100];
         this.temp_over_threshold = this.temperature > Schema.get_int('thermal-threshold');
         this.vals = [this.temperature];
         this.tip_vals[0] = this.temperature_text();

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2081,7 +2081,7 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
         this.temp_over_threshold = this.temperature > Schema.get_int('thermal-threshold');
         this.vals = [this.temperature];
         this.tip_vals[0] = this.temperature_text();
-        this.menu_items[1].text = this.temperature_symbol();
+        this.text_items[1].text = this.menu_items[1].text = this.temperature_symbol();
         this.tip_unit_labels[0].text = _(this.temperature_symbol());
     }
     create_text_items() {

--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2066,9 +2066,6 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
             file.load_contents_async(null, (source, result) => {
                 let as_r = source.load_contents_finish(result)
                 this.temperature = Math.round(parseInt(parse_bytearray(as_r[1])) / 1000);
-                if (this.fahrenheit_unit) {
-                    this.temperature = Math.round(this.temperature * 1.8 + 32);
-                }
             });
         } else if (this.display_error) {
             global.logError('error reading: ' + sfile);
@@ -2110,7 +2107,11 @@ const Thermal = class SystemMonitor_Thermal extends ElementBase {
         ];
     }
     temperature_text() {
-        return this.temperature.toString();
+        let temperature = this.temperature;
+        if (this.fahrenheit_unit) {
+            temperature = Math.round(temperature * 1.8 + 32);
+        }
+        return temperature.toString();
     }
     temperature_symbol() {
         return this.fahrenheit_unit ? '°F' : '°C';


### PR DESCRIPTION
- Don't use compatibility characters for temperature symbols. See of https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/562 and https://stackoverflow.com/a/10799833/3025505.
- Don't convert to Fahrenheit until showing as text. For the graphs it doesn't matter which unit the values are in, as long as all the values are in the same unit. See https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/571.
- Update temperature unit in menu. Fixes https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/571.
- Remove obsolete comment, since there is a max value of 100°C introduced in https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/commit/be41d9c42499e6c2c5b4ea56e3034fdc3698d694.

Should also fix https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/344.