### PR TITLE
prefs: Remove clutter dependency on GNOME 40

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -9,7 +9,6 @@ const Gettext = imports.gettext.domain('system-monitor');
 
 let extension = imports.misc.extensionUtils.getCurrentExtension();
 let convenience = extension.imports.convenience;
-let Compat = extension.imports.compat;
 
 const _ = Gettext.gettext;
 const N_ = function (e) {
@@ -187,10 +186,20 @@ const ColorSelect = class SystemMonitor_ColorSelect {
         this.picker.set_use_alpha(true);
     }
     set_value(value) {
-        let clutterColor = Compat.color_from_string(value);
         let color = new Gdk.RGBA();
-        let ctemp = [clutterColor.red, clutterColor.green, clutterColor.blue, clutterColor.alpha / 255];
-        color.parse('rgba(' + ctemp.join(',') + ')');
+
+        if (Gtk.get_major_version() >= 4) {
+            // GDK did not support parsing hex colours with alpha before GTK 4.
+            color.parse(value);
+        } else {
+            // Use the Compat only when GTK 4 is not available,
+            // since it depends on the deprecated Clutter library.
+            let Compat = extension.imports.compat;
+            let clutterColor = Compat.color_from_string(value);
+            let ctemp = [clutterColor.red, clutterColor.green, clutterColor.blue, clutterColor.alpha / 255];
+            color.parse('rgba(' + ctemp.join(',') + ')');
+        }
+
         this.picker.set_rgba(color);
     }
 }


### PR DESCRIPTION
There is a strict distinction between GNOME Shell using the Clutter toolkit and apps (including extension preferences) using GTK.

And while it is technically possible for apps to use Clutter, the library is unmaintained and its use is discouraged. Additionally, GNOME Shell actually uses its own internal fork of Clutter so if we depend on Clutter, we need to install a second copy of it just for the preferences.

Fortunately, GDK 4 [supports parsing hex colours with alpha values](https://gitlab.gnome.org/GNOME/gtk/merge_requests/2356), so we can just use it directly without depending on Clutter.

We will only use the Compat module when GTK 4 is not available, such as on GNOME < 40.
