### PR TITLE
Change ordering to be consistent with standard perf order.

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2442,8 +2442,8 @@ function enable() {
         Main.__sm.elts = createCpus();
         Main.__sm.elts.push(new Freq());
         Main.__sm.elts.push(new Mem());
-        Main.__sm.elts.push(new Swap());
         Main.__sm.elts.push(new Net());
+        Main.__sm.elts.push(new Swap());
         Main.__sm.elts.push(new Disk());
         Main.__sm.elts.push(new Gpu());
         Main.__sm.elts.push(new Thermal());

--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -465,7 +465,7 @@ const SettingFrame = class SystemMonitor {
 
 const App = class SystemMonitor_App {
     constructor() {
-        let setting_items = ['cpu', 'memory', 'swap', 'net', 'disk', 'gpu', 'thermal', 'fan', 'freq', 'battery'];
+        let setting_items = ['cpu', 'memory', 'net', 'swap', 'disk', 'gpu', 'thermal', 'fan', 'freq', 'battery'];
         let keys = Schema.list_keys();
 
         this.items = [];


### PR DESCRIPTION
This restores the original order that was present in the classic GNOME
2.x system monitor that inspired this extension. Of course if this order
  was easily configurable by the user, that would be preferable.