### PR TITLE
Fix git error in PKGBUILD

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -11,7 +11,7 @@ makedepends=('git')
 provides=("system-monitor-applet")
 #install=gschemas.install
 
-_gitroot="git://github.com/paradoxxxzero/gnome-shell-system-monitor-applet.git"
+_gitroot="https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet.git"
 _gitname="gnome-shell-system-monitor-applet"
 
 build() {


### PR DESCRIPTION
With the `git://` url, mkpkg would fail with
```
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
Changing the url to an https one lets the package build successfully.