### PR TITLE
Fix a small typo in extension.js

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -1578,7 +1578,7 @@ const Disk = class SystemMonitor_Disk extends ElementBase {
                 text: Style.diskunits(),
                 style_class: Style.get('sm-label')}),
             new St.Label({
-                text: _('R'),
+                text: ' ' + _('R'),
                 style_class: Style.get('sm-label')}),
             new St.Label({
                 text: '',


### PR DESCRIPTION
Fix a small typo in the Disk menu. There was a missing space between /s and R.