### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # https://docs.travis-ci.com/user/multi-os/
 # https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
-dist: xenial
+dist: focal
 sudo: required
 language: node_js
 node_js: node


### PR DESCRIPTION
Update travis dist version to unlock Gnome 43 compatibility patch building.
As per https://github.com/nodejs/node/issues/42351#issuecomment-1068424442 travis fails for Node build on platform older than Ubuntu 18.10 due to lack of Glibc.
This repo still uses 16.04 and this blocks deployment of https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/754, making the extension unusable on Gnome 43.
Updating that **should** unlock the PR.