### PR TITLE
Add setting for tooltip delay

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -870,7 +870,7 @@ const TipBox = class SystemMonitor_TipBox {
             this.out_to = 0;
         }
         if (!this.in_to) {
-            this.in_to = Mainloop.timeout_add(500,
+            this.in_to = Mainloop.timeout_add(Schema.get_int('tooltip-delay-ms'),
                 this.show_tip.bind(this));
         }
     }
@@ -880,7 +880,7 @@ const TipBox = class SystemMonitor_TipBox {
             this.in_to = 0;
         }
         if (!this.out_to) {
-            this.out_to = Mainloop.timeout_add(500,
+            this.out_to = Mainloop.timeout_add(Schema.get_int('tooltip-delay-ms'),
                 this.hide_tip.bind(this));
         }
     }

--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -507,6 +507,12 @@ const App = class SystemMonitor_App {
                 this.items.push(item)
                 this.hbox1.add(item)
                 Schema.bind(key, item, 'active', Gio.SettingsBindFlags.DEFAULT);
+            } else if (key === 'tooltip-delay-ms') {
+                let item = new IntSelect(_('Tooltip delay'));
+                item.set_args(0, 100000, 50, 1000);
+                this.items.push(item)
+                this.hbox1.add(item.actor);
+                Schema.bind(key, item.spin, 'value', Gio.SettingsBindFlags.DEFAULT);
             } else if (key === 'move-clock') {
                 let item = new Gtk.CheckButton({label: _('Move the clock')})
                 this.items.push(item)

--- a/system-monitor@paradoxxx.zero.gmail.com/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
+++ b/system-monitor@paradoxxx.zero.gmail.com/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
@@ -323,6 +323,11 @@
       <summary>Enable or disable the tooltip</summary>
       <description>True: show tool tip on mouse hover </description>
     </key>
+    <key name="tooltip-delay-ms" type="i">
+      <default>0</default>
+      <summary>Tooltip delay</summary>
+      <description>Milliseconds to wait before showing/hiding a tooltip</description>
+    </key>
     <key name="compact-display" type="b">
       <default>false</default>
       <summary>Optimize view for small displays</summary>


### PR DESCRIPTION
Resolves https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/770.

And make it 0 by default rather than 500ms.

The row of general settings is getting long - it might be good to break it up over a couple of rows.