### PR TITLE
Remove "nvidia gpu only" message

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -454,11 +454,6 @@ const SettingFrame = class SystemMonitor {
             this.hbox3.add(item.actor);
             Schema.bind(key, item.spin, 'value', Gio.SettingsBindFlags.DEFAULT);
         }
-        if (configParent.indexOf('gpu') !== -1 &&
-            config === 'display') {
-            let item = new Gtk.Label({label: _('** Only Nvidia GPUs supported so far **')});
-            this.hbox3.add(item);
-        }
         this._reorder();
     }
 }


### PR DESCRIPTION
Resolves https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/769