### PR TITLE
Continue running when screen is locked and optionally show on lockscreen, using session modes

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -2396,6 +2396,14 @@ function init() {
     IconSize = Math.round(Panel.PANEL_ICON_SIZE * 4 / 5);
 }
 
+function _onSessionModeChanged(session) {
+    if (session.currentMode === 'user' || session.parentMode === 'user') {
+        Main.__sm.tray.show()
+    } else if (session.currentMode === 'unlock-dialog' && !Schema.get_boolean('show-on-lockscreen')) {
+        Main.__sm.tray.hide()
+    }
+}
+
 function enable() {
     log('[System monitor] applet enabling');
     Schema = Convenience.getSettings();
@@ -2547,6 +2555,10 @@ function enable() {
         });
         tray.menu.addMenuItem(item);
         Main.panel.menuManager.addMenu(tray.menu);
+
+        if (shell_Version >= '42') {
+            Main.sessionMode.connect('updated', _onSessionModeChanged);
+        }
     }
     log('[System monitor] applet enabling done');
 }

--- a/system-monitor@paradoxxx.zero.gmail.com/metadata.json
+++ b/system-monitor@paradoxxx.zero.gmail.com/metadata.json
@@ -6,5 +6,6 @@
     "description": "Display system information in GNOME Shell status bar, such as memory, CPU, disk and battery usages, network rates…",
     "settings-schema":  "org.gnome.shell.extensions.system-monitor",
     "gettext-domain": "system-monitor",
+    "session-modes": ["user", "unlock-dialog"],
     "version": -1
 }

--- a/system-monitor@paradoxxx.zero.gmail.com/prefs.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/prefs.js
@@ -512,6 +512,11 @@ const App = class SystemMonitor_App {
                 this.items.push(item)
                 this.hbox1.add(item)
                 Schema.bind(key, item, 'active', Gio.SettingsBindFlags.DEFAULT);
+            } else if (key === 'show-on-lockscreen') {
+                let item = new Gtk.CheckButton({label: _('Show on lockscreen')})
+                this.items.push(item)
+                this.hbox1.add(item)
+                Schema.bind(key, item, 'active', Gio.SettingsBindFlags.DEFAULT);
             } else if (key === 'background') {
                 let item = new ColorSelect(_('Background Color'))
                 item.set_value(Schema.get_string(key))

--- a/system-monitor@paradoxxx.zero.gmail.com/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
+++ b/system-monitor@paradoxxx.zero.gmail.com/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
@@ -328,6 +328,11 @@
       <summary>Optimize view for small displays</summary>
       <description>Optimize texts sizes to fit on a small display </description>
     </key>
+    <key name="show-on-lockscreen" type="b">
+      <default>false</default>
+      <summary>Show on lockscreen</summary>
+      <description>Allow the extension to run while the screen is locked. Also avoids resetting graph history</description>
+    </key>
     <key name="memory-program-color" type="s">
       <default>'#00b35b'</default>
       <summary>Color of program memory in the chart</summary>


### PR DESCRIPTION
Resolves https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/329. Resolves https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/624. On Gnome Shell 42+, that is.

This change allow the extension to continue running while the screen is locked, in an officially-supported manner - by making use of the new [session modes feature introduced in Gnome Shell 42](https://gjs.guide/extensions/topics/session-modes.html). This is as opposed to the frowned-upon approach of disabling the `disable()` function (as [implemented](https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/329#issuecomment-377823916) by @franglais125), which would apparently prevent publishing to the Gnome Extensions website, and also mean the user can't turn off the extension without removing it.

I've added an option to choose whether the applet should be shown on the lockscreen. When not enabled, the applet is simply hidden. And it's hidden on the lockscreen by default.

Strangely, disconnecting the session mode updated callback in `disable()`, like in [the example code](https://gjs.guide/extensions/topics/session-modes.html), resulted in the applet still being shown the first time the screen is locked. I couldn't work out what that was happening. But it seems to work fine with it left out, so I've just done that.

I developed this on Gnome 43.2, while branched from https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/pull/754 by necessity; but it should work here on Gnome 42 as well. And hopefully it changes nothing on older versions of Gnome.

Screenshots (from my fork - there's a couple of other changes in there, but you get the gist):

![Screenshot from 2023-01-19 02-24-12](https://user-images.githubusercontent.com/2916331/213212118-331956f5-8559-40cf-ad70-074cd9adae63.png)

![Screenshot from 2023-01-19 02-25-00 - annotated](https://user-images.githubusercontent.com/2916331/213212623-20b427cf-7d3b-4cce-825a-71a556d65f95.png)