### PR TITLE
Disable Python output buffering

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 ./docker/build-docker.sh
-./docker/run_and_kill.py || true
+python -u ./docker/run_and_kill.py || true
 ./docker/check_output.sh


### PR DESCRIPTION
This should make build logs less confusing

https://stackoverflow.com/questions/107705/disable-output-buffering