### PR TITLE
Fix dependency tree in Makefile to ensure schema is built *after* it's dropped when running in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ zip-file.clean:
 
 PHONY += extension extension.clean _drop-gschemas
 
-extension: _drop-gschemas ./$(UUID)/schemas/gschemas.compiled
+extension: ./$(UUID)/schemas/gschemas.compiled
 	$(call msg,$@,OK)
 
 clean:: extension.clean
@@ -142,7 +142,7 @@ extension.clean:
 	$(Q)git checkout -f -- ./$(UUID)/schemas/gschemas.compiled
 	$(call msg,$@,OK)
 
-./$(UUID)/schemas/gschemas.compiled: ./$(UUID)/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
+./$(UUID)/schemas/gschemas.compiled: _drop-gschemas ./$(UUID)/schemas/org.gnome.shell.extensions.system-monitor.gschema.xml
 	$(Q)glib-compile-schemas ./$(UUID)/schemas/
 	$(call msg,gschemas,OK)
 


### PR DESCRIPTION
Resolves https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/786.

I barely have any experience with Makefiles, but managed to figure this one out pretty quickly.

Previously, when using `-j4`, it was showing an error on every second run:

```
➜ make -j4 install
  [remove      ]
/home/brendan/.local/share/gnome-shell/extensions/system-monitor@paradoxxx.zero.gmail.com
  [extension   ] OK
Reloading extensions does not work correctly and is no longer supported
  [reload      ] OK
  [remove      ] OK
  [translate   ] ar/ ca/ cs/ de/ es_ES/ es_MX/ fa/ fi/ fr/ hu/ it/ ja/
ko/ nl_NL/ pl/ pt/ pt_BR/ ro/ ru/ sk/ tr/ uk/ zh_CN/
  [translate   ] OK
cp: cannot stat
'system-monitor@paradoxxx.zero.gmail.com/schemas/gschemas.compiled': No
such file or directory
make: *** [Makefile:162: build] Error 1
```

Now it works consistently:

```
➜ make -j4 install
  [remove      ]
/home/brendan/.local/share/gnome-shell/extensions/system-monitor@paradoxxx.zero.gmail.com
  [gschemas    ] OK
  [extension   ] OK
Reloading extensions does not work correctly and is no longer supported
  [reload      ] OK
  [remove      ] OK
  [translate   ] ar/ ca/ cs/ de/ es_ES/ es_MX/ fa/ fi/ fr/ hu/ it/ ja/
ko/ nl_NL/ pl/ pt/ pt_BR/ ro/ ru/ sk/ tr/ uk/ zh_CN/
  [translate   ] OK
  [build       ] OK
  [install     ]
/home/brendan/.local/share/gnome-shell/extensions/system-monitor@paradoxxx.zero.gmail.com
Reloading extensions does not work correctly and is no longer supported
  [reload      ] OK
  [install     ] OK
```