### PR TITLE
metadata: mark 44 as a supported version

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/metadata.json
+++ b/system-monitor@paradoxxx.zero.gmail.com/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.26", "3.28", "3.30", "3.32", "3.34", "3.36", "40", "41", "42", "43"],
+    "shell-version": ["3.26", "3.28", "3.30", "3.32", "3.34", "3.36", "40", "41", "42", "43", "44"],
     "uuid": "system-monitor@paradoxxx.zero.gmail.com",
     "name": "system-monitor",
     "url": "https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet",


### PR DESCRIPTION
I'm using GNOME 44 beta (44~beta-1ubuntu1 on Ubuntu 23.04 with Wayland) and it looks like everything seems working fine after having forced version 44 support in metadata.js when using the development version of this add-on.

So I guess we can simply update this `metadata.js` file to allow this nice add-on to run on newer GNOME versions.