### PR TITLE
Handle missing mountpoints in is_sys_mount

### DIFF
--- a/system-monitor@paradoxxx.zero.gmail.com/extension.js
+++ b/system-monitor@paradoxxx.zero.gmail.com/extension.js
@@ -489,9 +489,16 @@ const smMountsMonitor = class SystemMonitor_smMountsMonitor {
     }
     is_sys_mount(mpath) {
         let file = Gio.file_new_for_path(mpath);
-        let info = file.query_info(Gio.FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT,
-            Gio.FileQueryInfoFlags.NONE, null);
-        return info.get_attribute_boolean(Gio.FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT);
+        try {
+            let info = file.query_info(Gio.FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT,
+                Gio.FileQueryInfoFlags.NONE, null);
+            return info.get_attribute_boolean(Gio.FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT);
+        } catch (e) {
+            if (e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.NOT_FOUND)) {
+                return false;
+            }
+            throw e;
+        }
     }
     is_ro_mount(mount) {
         // FIXME: running this function after "login after waking from suspend"


### PR DESCRIPTION
On NixOS, /usr/local does not exist. Handle this error gracefully.