### PR TITLE
Deprecate extension in favour of mgalgs fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ## GNOME Shell system monitor extension
 
+> [!IMPORTANT]
+> This repository has been deprecated in favour of this fork: https://github.com/mgalgs/gnome-shell-system-monitor-next-applet
+>
+> See there for support beyond GNOME Shell 40
+
 [![Build Status](https://travis-ci.com/paradoxxxzero/gnome-shell-system-monitor-applet.svg?branch=master)](https://travis-ci.com/paradoxxxzero/gnome-shell-system-monitor-applet)
 
 ![screenshot-small](http://i.imgur.com/ka9OA.png)


### PR DESCRIPTION
See https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/issues/767

Using GitHub's Markdown syntax for notices from: https://github.com/orgs/community/discussions/16925